### PR TITLE
Add jar detail page

### DIFF
--- a/app/jars/[id]/__tests__/page.test.tsx
+++ b/app/jars/[id]/__tests__/page.test.tsx
@@ -1,0 +1,172 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+
+import { JARS_STORAGE_KEY } from "../../../../lib/storage";
+import JarDetailPage from "../page";
+
+const routeParams = vi.hoisted(() => ({ id: "jar-1" }));
+
+vi.mock("next/navigation", () => ({
+  useParams: () => routeParams,
+}));
+
+describe("JarDetailPage", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    routeParams.id = "jar-1";
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-06-09T12:00:00.000Z"));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("adds today's marble to localStorage and updates the page", () => {
+    localStorage.setItem(
+      JARS_STORAGE_KEY,
+      JSON.stringify([
+        {
+          id: "jar-1",
+          name: "Daily reading",
+          target: 5,
+          color: "mint",
+          marbles: [
+            { date: "2026-06-07", at: "2026-06-07T12:00:00.000Z" },
+            { date: "2026-06-08", at: "2026-06-08T12:00:00.000Z" },
+          ],
+          createdAt: "2026-06-01T12:00:00.000Z",
+        },
+      ]),
+    );
+
+    render(<JarDetailPage />);
+
+    expect(screen.getByText("2 / 5 marbles")).toBeInTheDocument();
+    fireEvent.click(
+      screen.getByRole("button", { name: "Add today's marble" }),
+    );
+
+    expect(
+      screen.getByRole("button", { name: "Done for today ✓" }),
+    ).toBeDisabled();
+    expect(screen.getByText("3 / 5 marbles")).toBeInTheDocument();
+    expect(
+      screen.getByRole("img", { name: "Daily reading jar is 60% full" }),
+    ).toBeInTheDocument();
+    expect(JSON.parse(localStorage.getItem(JARS_STORAGE_KEY) ?? "[]")).toEqual([
+      {
+        id: "jar-1",
+        name: "Daily reading",
+        target: 5,
+        color: "mint",
+        marbles: [
+          { date: "2026-06-07", at: "2026-06-07T12:00:00.000Z" },
+          { date: "2026-06-08", at: "2026-06-08T12:00:00.000Z" },
+          { date: "2026-06-09", at: "2026-06-09T12:00:00.000Z" },
+        ],
+        createdAt: "2026-06-01T12:00:00.000Z",
+      },
+    ]);
+  });
+
+  it("disables the add button when today's marble already exists", () => {
+    localStorage.setItem(
+      JARS_STORAGE_KEY,
+      JSON.stringify([
+        {
+          id: "jar-1",
+          name: "Morning walk",
+          target: 10,
+          color: "coral",
+          marbles: [
+            { date: "2026-06-07", at: "2026-06-07T12:00:00.000Z" },
+            { date: "2026-06-08", at: "2026-06-08T12:00:00.000Z" },
+            { date: "2026-06-09", at: "2026-06-09T12:00:00.000Z" },
+          ],
+          createdAt: "2026-06-01T12:00:00.000Z",
+        },
+      ]),
+    );
+
+    render(<JarDetailPage />);
+
+    const button = screen.getByRole("button", {
+      name: "Done for today ✓",
+    });
+
+    expect(button).toBeDisabled();
+    expect(screen.getByText("3 days in a row 🔥")).toBeInTheDocument();
+
+    fireEvent.click(button);
+
+    const storedJars = JSON.parse(
+      localStorage.getItem(JARS_STORAGE_KEY) ?? "[]",
+    );
+
+    expect(storedJars[0].marbles).toHaveLength(3);
+  });
+
+  it("renders the last 14 days with filled, missed, and today-pending states", () => {
+    localStorage.setItem(
+      JARS_STORAGE_KEY,
+      JSON.stringify([
+        {
+          id: "jar-1",
+          name: "Water plants",
+          target: 14,
+          color: "sage",
+          marbles: [
+            { date: "2026-05-27", at: "2026-05-27T12:00:00.000Z" },
+            { date: "2026-06-02", at: "2026-06-02T12:00:00.000Z" },
+            { date: "2026-06-08", at: "2026-06-08T12:00:00.000Z" },
+          ],
+          createdAt: "2026-05-01T12:00:00.000Z",
+        },
+      ]),
+    );
+
+    render(<JarDetailPage />);
+
+    expect(
+      screen.getByRole("heading", { name: "Last 14 days" }),
+    ).toBeInTheDocument();
+    expect(screen.getAllByText("•")).toHaveLength(3);
+    expect(screen.getAllByText("○")).toHaveLength(10);
+    expect(screen.getByText("?")).toBeInTheDocument();
+    expect(
+      screen.getByRole("img", { name: "2026-05-27: marble added" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("img", { name: "2026-06-01: missed" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("img", { name: "2026-06-09: not added yet" }),
+    ).toBeInTheDocument();
+  });
+
+  it("renders a 404 state when the jar id is not stored", () => {
+    routeParams.id = "missing-jar";
+    localStorage.setItem(
+      JARS_STORAGE_KEY,
+      JSON.stringify([
+        {
+          id: "jar-1",
+          name: "Daily reading",
+          target: 5,
+          color: "mint",
+          marbles: [],
+          createdAt: "2026-06-01T12:00:00.000Z",
+        },
+      ]),
+    );
+
+    render(<JarDetailPage />);
+
+    expect(
+      screen.getByRole("heading", { name: "Jar not found" }),
+    ).toBeInTheDocument();
+    expect(screen.getByText("404")).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "Back to jars" }))
+      .toHaveAttribute("href", "/");
+  });
+});

--- a/app/jars/[id]/page.tsx
+++ b/app/jars/[id]/page.tsx
@@ -1,0 +1,326 @@
+"use client";
+
+import Link from "next/link";
+import { useParams } from "next/navigation";
+import { useEffect, useMemo, useState } from "react";
+
+import {
+  type Jar,
+  type MarbleEntry,
+  loadJars,
+  saveJars,
+} from "../../../lib/storage";
+
+const jarColorStyles = {
+  coral: {
+    fill: "bg-coral/35",
+    dot: "bg-coral",
+    border: "border-coral/70",
+    tint: "bg-coral/10",
+  },
+  mint: {
+    fill: "bg-mint/35",
+    dot: "bg-mint",
+    border: "border-mint/70",
+    tint: "bg-mint/10",
+  },
+  lavender: {
+    fill: "bg-lavender/35",
+    dot: "bg-lavender",
+    border: "border-lavender/70",
+    tint: "bg-lavender/10",
+  },
+  butter: {
+    fill: "bg-butter/45",
+    dot: "bg-butter",
+    border: "border-butter/70",
+    tint: "bg-butter/15",
+  },
+  sky: {
+    fill: "bg-sky/35",
+    dot: "bg-sky",
+    border: "border-sky/70",
+    tint: "bg-sky/10",
+  },
+  peach: {
+    fill: "bg-peach/35",
+    dot: "bg-peach",
+    border: "border-peach/70",
+    tint: "bg-peach/10",
+  },
+  lilac: {
+    fill: "bg-lilac/35",
+    dot: "bg-lilac",
+    border: "border-lilac/70",
+    tint: "bg-lilac/10",
+  },
+  sage: {
+    fill: "bg-sage/35",
+    dot: "bg-sage",
+    border: "border-sage/70",
+    tint: "bg-sage/10",
+  },
+} as const;
+
+function getJarColorStyles(color: string) {
+  return (
+    jarColorStyles[color as keyof typeof jarColorStyles] ??
+    jarColorStyles.coral
+  );
+}
+
+function getTodayDate() {
+  return new Date().toISOString().slice(0, 10);
+}
+
+function shiftDate(date: string, offsetDays: number) {
+  const shiftedDate = new Date(`${date}T00:00:00.000Z`);
+  shiftedDate.setUTCDate(shiftedDate.getUTCDate() + offsetDays);
+
+  return shiftedDate.toISOString().slice(0, 10);
+}
+
+function getMarbleDate(marble: MarbleEntry) {
+  return typeof marble === "string" ? marble : marble.date;
+}
+
+function getMarbleDateSet(marbles: MarbleEntry[]) {
+  return new Set(
+    marbles
+      .map((marble) => getMarbleDate(marble))
+      .filter((date) => /^\d{4}-\d{2}-\d{2}$/.test(date)),
+  );
+}
+
+function getFillPercent(jar: Jar) {
+  if (jar.target <= 0) {
+    return 0;
+  }
+
+  return Math.min(100, Math.round((jar.marbles.length / jar.target) * 100));
+}
+
+function getStreakCount(marbleDates: Set<string>, today: string) {
+  let streak = 0;
+  let cursorDate = today;
+
+  while (marbleDates.has(cursorDate)) {
+    streak += 1;
+    cursorDate = shiftDate(cursorDate, -1);
+  }
+
+  return streak;
+}
+
+function getLastFourteenDays(today: string) {
+  return Array.from({ length: 14 }, (_, index) => shiftDate(today, index - 13));
+}
+
+function NotFoundState() {
+  return (
+    <section className="mx-auto flex min-h-[calc(100vh-88px)] w-full max-w-3xl flex-col items-center justify-center px-5 pb-16 text-center">
+      <p className="text-sm font-semibold uppercase tracking-wide text-soft-ink">
+        404
+      </p>
+      <h1 className="mt-3 font-heading text-4xl font-semibold leading-tight text-ink">
+        Jar not found
+      </h1>
+      <p className="mt-4 max-w-md text-base leading-7 text-soft-ink">
+        This jar is not saved in this browser.
+      </p>
+      <Link
+        className="mt-8 rounded-lg bg-ink px-5 py-3 text-sm font-semibold text-cream shadow-sm transition hover:bg-soft-ink focus:outline-none focus:ring-2 focus:ring-ink focus:ring-offset-2 focus:ring-offset-cream"
+        href="/"
+      >
+        Back to jars
+      </Link>
+    </section>
+  );
+}
+
+function LargeJar({ jar }: { jar: Jar }) {
+  const colorStyles = getJarColorStyles(jar.color);
+  const fillPercent = getFillPercent(jar);
+  const previewMarbles = jar.marbles.slice(-24);
+
+  return (
+    <div
+      aria-label={`${jar.name} jar is ${fillPercent}% full`}
+      className="relative mx-auto h-[430px] w-full max-w-[340px] sm:h-[500px] sm:max-w-[400px]"
+      role="img"
+    >
+      <div className="absolute left-1/2 top-0 h-10 w-40 -translate-x-1/2 rounded-t-lg border-4 border-ink/75 bg-glass" />
+      <div className="absolute left-1/2 top-9 h-12 w-56 -translate-x-1/2 rounded-xl border-4 border-ink/75 bg-glass" />
+      <div className="absolute bottom-0 left-1/2 h-[370px] w-full -translate-x-1/2 overflow-hidden rounded-b-[4rem] rounded-t-[2rem] border-4 border-ink/75 bg-white/60 shadow-inner sm:h-[430px]">
+        <div
+          className={`absolute bottom-0 left-0 w-full transition-all ${colorStyles.fill}`}
+          style={{ height: `${fillPercent}%` }}
+        />
+        <div
+          aria-hidden="true"
+          className="absolute inset-x-10 bottom-8 grid grid-cols-4 gap-3 sm:grid-cols-6"
+        >
+          {previewMarbles.map((marble, index) => (
+            <span
+              className={`h-8 w-8 rounded-full shadow-sm ring-2 ring-white/80 ${colorStyles.dot}`}
+              key={`${getMarbleDate(marble)}-${index}`}
+            />
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function HistoryGrid({
+  marbleDates,
+  today,
+  color,
+}: {
+  marbleDates: Set<string>;
+  today: string;
+  color: string;
+}) {
+  const colorStyles = getJarColorStyles(color);
+  const days = getLastFourteenDays(today);
+
+  return (
+    <section className="mt-10 border-t border-line pt-7">
+      <h2 className="font-heading text-2xl font-semibold text-ink">
+        Last 14 days
+      </h2>
+      <div className="mt-4 grid grid-cols-7 gap-3 md:grid-cols-[repeat(14,2.75rem)]">
+        {days.map((date) => {
+          const hasMarble = marbleDates.has(date);
+          const isToday = date === today;
+          const symbol = hasMarble ? "•" : isToday ? "?" : "○";
+          const label = hasMarble
+            ? `${date}: marble added`
+            : isToday
+              ? `${date}: not added yet`
+              : `${date}: missed`;
+
+          return (
+            <span
+              aria-label={label}
+              className={`flex h-11 w-11 items-center justify-center rounded-full border text-xl font-semibold shadow-sm ${
+                hasMarble
+                  ? `${colorStyles.dot} border-transparent text-white`
+                  : "border-line bg-white text-soft-ink"
+              }`}
+              key={date}
+              role="img"
+              title={date}
+            >
+              {symbol}
+            </span>
+          );
+        })}
+      </div>
+    </section>
+  );
+}
+
+export default function JarDetailPage() {
+  const params = useParams<{ id: string }>();
+  const jarId = params.id;
+  const [jar, setJar] = useState<Jar | null>(null);
+  const [hasLoaded, setHasLoaded] = useState(false);
+  const today = getTodayDate();
+
+  useEffect(() => {
+    const storedJar = loadJars().find(
+      (candidateJar) => candidateJar.id === jarId,
+    );
+
+    setJar(storedJar ?? null);
+    setHasLoaded(true);
+  }, [jarId]);
+
+  const marbleDates = useMemo(
+    () => getMarbleDateSet(jar?.marbles ?? []),
+    [jar?.marbles],
+  );
+  const isDoneToday = marbleDates.has(today);
+  const streakCount = getStreakCount(marbleDates, today);
+
+  const handleAddToday = () => {
+    if (!jar || isDoneToday) {
+      return;
+    }
+
+    const updatedJar: Jar = {
+      ...jar,
+      marbles: [
+        ...jar.marbles,
+        {
+          date: today,
+          at: new Date().toISOString(),
+        },
+      ],
+    };
+    const updatedJars = loadJars().map((candidateJar) =>
+      candidateJar.id === jar.id ? updatedJar : candidateJar,
+    );
+
+    saveJars(updatedJars);
+    setJar(updatedJar);
+  };
+
+  if (!hasLoaded) {
+    return null;
+  }
+
+  if (!jar) {
+    return <NotFoundState />;
+  }
+
+  const colorStyles = getJarColorStyles(jar.color);
+  const fillPercent = getFillPercent(jar);
+
+  return (
+    <section className="mx-auto min-h-[calc(100vh-88px)] w-full max-w-6xl px-5 pb-16 pt-6">
+      <Link
+        className="inline-flex rounded-lg border border-line bg-white px-4 py-2 text-sm font-semibold text-ink shadow-sm transition hover:border-soft-ink focus:outline-none focus:ring-2 focus:ring-ink focus:ring-offset-2 focus:ring-offset-cream"
+        href="/"
+      >
+        Back
+      </Link>
+
+      <div className="mt-6 grid gap-8 lg:grid-cols-[minmax(0,400px)_minmax(0,1fr)] lg:items-center">
+        <aside
+          className={`rounded-lg border ${colorStyles.border} ${colorStyles.tint} px-5 py-8 shadow-sm`}
+        >
+          <LargeJar jar={jar} />
+        </aside>
+
+        <div>
+          <h1 className="font-heading text-4xl font-semibold leading-tight text-ink sm:text-5xl">
+            {jar.name}
+          </h1>
+          {streakCount >= 3 ? (
+            <p className="mt-4 text-lg font-semibold text-soft-ink">
+              {streakCount} days in a row 🔥
+            </p>
+          ) : null}
+          <p className="mt-5 text-xl font-semibold text-ink">
+            {jar.marbles.length} / {jar.target} marbles
+          </p>
+          <p className="mt-2 text-sm font-medium text-soft-ink">
+            {fillPercent}% full
+          </p>
+          <button
+            className="mt-8 w-full rounded-lg bg-ink px-5 py-4 text-base font-semibold text-cream shadow-sm transition hover:bg-soft-ink focus:outline-none focus:ring-2 focus:ring-ink focus:ring-offset-2 focus:ring-offset-cream disabled:cursor-not-allowed disabled:bg-soft-ink/45 sm:w-auto"
+            disabled={isDoneToday}
+            onClick={handleAddToday}
+            type="button"
+          >
+            {isDoneToday ? "Done for today ✓" : "Add today's marble"}
+          </button>
+        </div>
+      </div>
+
+      <HistoryGrid marbleDates={marbleDates} today={today} color={jar.color} />
+    </section>
+  );
+}

--- a/lib/storage.ts
+++ b/lib/storage.ts
@@ -1,11 +1,18 @@
 export const JARS_STORAGE_KEY = "streak-jar.jars";
 
+export type MarbleEntry =
+  | string
+  | {
+      date: string;
+      at: string;
+    };
+
 export type Jar = {
   id: string;
   name: string;
   target: number;
   color: string;
-  marbles: string[];
+  marbles: MarbleEntry[];
   createdAt: string;
 };
 


### PR DESCRIPTION
## Summary

Adds the focused jar detail route for viewing a habit jar, adding today's marble, and reviewing recent history from localStorage.

## Changes

- Add `/jars/[id]` route with a large CSS jar visual, habit stats, add-today CTA, streak display, and 14-day history grid
- Persist new marbles as dated `{ date, at }` entries while keeping existing string marble data count-compatible
- Add route tests for add-today, already-done-today, history rendering, and missing-jar 404 state

## Test Plan

- `pnpm tsc --noEmit`
- `pnpm test`
- `pnpm build`

Closes #8