### PR TITLE
[#10] add streak counter logic and badge

### DIFF
--- a/app/__tests__/page.test.tsx
+++ b/app/__tests__/page.test.tsx
@@ -3,6 +3,14 @@ import { render, screen } from "@testing-library/react";
 import { JARS_STORAGE_KEY } from "../../lib/storage";
 import Home from "../page";
 
+function getDateKey(offsetDays: number) {
+  const date = new Date();
+
+  date.setUTCDate(date.getUTCDate() + offsetDays);
+
+  return date.toISOString().slice(0, 10);
+}
+
 describe("Home", () => {
   beforeEach(() => {
     localStorage.clear();
@@ -30,7 +38,12 @@ describe("Home", () => {
           name: "Daily reading",
           target: 30,
           color: "mint",
-          marbles: Array.from({ length: 12 }, (_, index) => `m-${index}`),
+          marbles: [
+            getDateKey(-2),
+            getDateKey(-1),
+            getDateKey(0),
+            ...Array.from({ length: 9 }, (_, index) => `m-${index}`),
+          ],
           createdAt: "2026-06-09T12:00:00.000Z",
         },
         {
@@ -64,6 +77,7 @@ describe("Home", () => {
     expect(
       screen.getByRole("img", { name: "Daily reading jar is 40% full" }),
     ).toBeInTheDocument();
+    expect(screen.getByLabelText("3 day streak")).toHaveTextContent("🔥3");
     expect(screen.getByRole("link", { name: "+ New jar" })).toHaveAttribute(
       "href",
       "/jars/new",

--- a/app/jars/[id]/page.tsx
+++ b/app/jars/[id]/page.tsx
@@ -14,6 +14,7 @@ import {
   saveJars,
   saveJarStorage,
 } from "../../../lib/storage";
+import { computeStreak } from "../../../lib/streak";
 
 const CELEBRATION_DELAY_MS = 650;
 
@@ -104,18 +105,6 @@ function getFillPercent(jar: Jar) {
   }
 
   return Math.min(100, Math.round((jar.marbles.length / jar.target) * 100));
-}
-
-function getStreakCount(marbleDates: Set<string>, today: string) {
-  let streak = 0;
-  let cursorDate = today;
-
-  while (marbleDates.has(cursorDate)) {
-    streak += 1;
-    cursorDate = shiftDate(cursorDate, -1);
-  }
-
-  return streak;
 }
 
 function getLastFourteenDays(today: string) {
@@ -256,7 +245,7 @@ export default function JarDetailPage() {
     [jar?.marbles],
   );
   const isDoneToday = marbleDates.has(today);
-  const streakCount = getStreakCount(marbleDates, today);
+  const streakCount = computeStreak(jar?.marbles ?? []);
 
   const handleAddToday = () => {
     if (!jar || isDoneToday || jar.completedAt) {
@@ -369,7 +358,7 @@ export default function JarDetailPage() {
             </p>
           ) : null}
           {streakCount >= 3 ? (
-            <p className="mt-4 text-lg font-semibold text-soft-ink">
+            <p className="mt-4 inline-flex rounded-full border border-butter/70 bg-butter/20 px-3 py-1 text-sm font-semibold text-ink">
               {streakCount} days in a row 🔥
             </p>
           ) : null}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -4,6 +4,7 @@ import Link from "next/link";
 import { useEffect, useState } from "react";
 
 import { type Jar, loadCompletedJars, loadJars } from "../lib/storage";
+import { computeStreak } from "../lib/streak";
 
 const emptyStateMarbleColors = [
   "bg-coral",
@@ -146,6 +147,7 @@ function MiniJar({ jar }: { jar: Jar }) {
 
 function JarCard({ jar }: { jar: Jar }) {
   const colorStyles = getJarColorStyles(jar.color);
+  const streakCount = computeStreak(jar.marbles);
 
   return (
     <Link
@@ -165,6 +167,15 @@ function JarCard({ jar }: { jar: Jar }) {
       <p className="mt-2 text-sm font-semibold text-soft-ink">
         {jar.marbles.length} / {jar.target}
       </p>
+      {streakCount >= 3 ? (
+        <p
+          aria-label={`${streakCount} day streak`}
+          className="mt-3 inline-flex items-center gap-1 rounded-full border border-butter/70 bg-butter/20 px-2.5 py-1 text-xs font-semibold text-ink"
+        >
+          <span aria-hidden="true">🔥</span>
+          <span>{streakCount}</span>
+        </p>
+      ) : null}
     </Link>
   );
 }

--- a/lib/streak.test.ts
+++ b/lib/streak.test.ts
@@ -1,0 +1,67 @@
+import { computeStreak, type Marble } from "./streak";
+
+describe("computeStreak", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-06-10T12:00:00.000Z"));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("returns 0 for an empty jar", () => {
+    expect(computeStreak([])).toBe(0);
+  });
+
+  it("counts only today as a one-day streak", () => {
+    expect(computeStreak(["2026-06-10"])).toBe(1);
+  });
+
+  it("counts today and yesterday as a two-day streak", () => {
+    expect(computeStreak(["2026-06-09", "2026-06-10"])).toBe(2);
+  });
+
+  it("counts a five-day streak through today", () => {
+    expect(
+      computeStreak([
+        "2026-06-06",
+        "2026-06-07",
+        "2026-06-08",
+        "2026-06-09",
+        "2026-06-10",
+      ]),
+    ).toBe(5);
+  });
+
+  it("returns 0 when today is missing even if yesterday exists", () => {
+    expect(computeStreak(["2026-06-09"])).toBe(0);
+  });
+
+  it("counts only from today back to a mid-history gap", () => {
+    expect(
+      computeStreak([
+        "2026-06-05",
+        "2026-06-06",
+        "2026-06-08",
+        "2026-06-09",
+        "2026-06-10",
+      ]),
+    ).toBe(3);
+  });
+
+  it("supports stored marble objects and ignores invalid legacy ids", () => {
+    const marbles: Marble[] = [
+      "legacy-id",
+      { date: "2026-06-08", at: "2026-06-08T12:00:00.000Z" },
+      { date: "2026-06-09", at: "2026-06-09T12:00:00.000Z" },
+      { date: "2026-06-10", at: "2026-06-10T12:00:00.000Z" },
+    ];
+
+    expect(computeStreak(marbles)).toBe(3);
+  });
+
+  it("returns 0 for marbles only from old dates", () => {
+    expect(computeStreak(["2026-05-01", "2026-05-02"])).toBe(0);
+  });
+});

--- a/lib/streak.ts
+++ b/lib/streak.ts
@@ -1,0 +1,39 @@
+import { type MarbleEntry } from "./storage";
+
+export type Marble = MarbleEntry;
+
+const dateKeyPattern = /^\d{4}-\d{2}-\d{2}$/;
+
+function getDateKey(date: Date) {
+  return date.toISOString().slice(0, 10);
+}
+
+function getMarbleDate(marble: Marble) {
+  return typeof marble === "string" ? marble : marble.date;
+}
+
+function shiftDateKey(dateKey: string, offsetDays: number) {
+  const [year, month, day] = dateKey.split("-").map(Number);
+  const date = new Date(Date.UTC(year, month - 1, day));
+
+  date.setUTCDate(date.getUTCDate() + offsetDays);
+
+  return getDateKey(date);
+}
+
+export function computeStreak(marbles: Marble[]): number {
+  const marbleDates = new Set(
+    marbles
+      .map((marble) => getMarbleDate(marble))
+      .filter((date) => dateKeyPattern.test(date)),
+  );
+  let streak = 0;
+  let cursorDate = getDateKey(new Date());
+
+  while (marbleDates.has(cursorDate)) {
+    streak += 1;
+    cursorDate = shiftDateKey(cursorDate, -1);
+  }
+
+  return streak;
+}


### PR DESCRIPTION
## Summary
- Added `computeStreak` in `lib/streak.ts` using UTC date keys and legacy marble filtering
- Displayed streak badges on jar detail and dashboard cards when the streak is at least 3 days
- Added unit coverage for streak edge cases plus dashboard badge coverage

## Test Plan
- pnpm test
- pnpm tsc --noEmit

Closes #10