### PR TITLE
fix: harden streak badge count

### DIFF
--- a/app/jar/__tests__/page.test.tsx
+++ b/app/jar/__tests__/page.test.tsx
@@ -132,28 +132,37 @@ describe("JarDetailPage", () => {
     expect(getStoredStorage().jars[0].marbles).toHaveLength(3);
   });
 
-  it("hides the streak badge when the computed streak is invalid", () => {
-    vi.spyOn(streak, "computeStreak").mockReturnValue(Number.NaN);
-    seedStorage([
-      {
-        id: "jar-1",
-        name: "Morning walk",
-        target: 10,
-        color: "coral",
-        marbles: [
-          { date: "2026-06-07", at: "2026-06-07T12:00:00.000Z" },
-          { date: "2026-06-08", at: "2026-06-08T12:00:00.000Z" },
-          { date: "2026-06-09", at: "2026-06-09T12:00:00.000Z" },
-        ],
-        createdAt: "2026-06-01T12:00:00.000Z",
-      },
-    ]);
+  it.each([
+    ["NaN", Number.NaN],
+    ["Infinity", Number.POSITIVE_INFINITY],
+    ["non-integer", 3.5],
+  ])(
+    "hides the streak badge when the computed streak is %s",
+    (_, streakCount) => {
+      vi.spyOn(streak, "computeStreak").mockReturnValue(streakCount);
+      seedStorage([
+        {
+          id: "jar-1",
+          name: "Morning walk",
+          target: 10,
+          color: "coral",
+          marbles: [
+            { date: "2026-06-07", at: "2026-06-07T12:00:00.000Z" },
+            { date: "2026-06-08", at: "2026-06-08T12:00:00.000Z" },
+            { date: "2026-06-09", at: "2026-06-09T12:00:00.000Z" },
+          ],
+          createdAt: "2026-06-01T12:00:00.000Z",
+        },
+      ]);
 
-    render(<JarDetailPage />);
+      render(<JarDetailPage />);
 
-    expect(screen.queryByText("NaN days in a row 🔥")).not.toBeInTheDocument();
-    expect(screen.queryByText(/days in a row/)).not.toBeInTheDocument();
-  });
+      expect(
+        screen.queryByText(`${streakCount} days in a row 🔥`),
+      ).not.toBeInTheDocument();
+      expect(screen.queryByText(/days in a row/)).not.toBeInTheDocument();
+    },
+  );
 
   it("shows a short drop message for a new streak", () => {
     seedStorage([

--- a/app/jar/__tests__/page.test.tsx
+++ b/app/jar/__tests__/page.test.tsx
@@ -5,6 +5,7 @@ import {
   type JarStorage,
   JARS_STORAGE_KEY,
 } from "../../../lib/storage";
+import * as streak from "../../../lib/streak";
 import JarDetailPage from "../page";
 
 function seedStorage(jars: Jar[], completed: Jar[] = []) {
@@ -34,7 +35,7 @@ function advanceToCelebration() {
 }
 
 function setJarQuery(id: string) {
-  window.history.replaceState({}, "", `http://localhost/jar?id=${id}`);
+  window.history.replaceState({}, "", `/jar?id=${id}`);
 }
 
 describe("JarDetailPage", () => {
@@ -46,6 +47,7 @@ describe("JarDetailPage", () => {
   });
 
   afterEach(() => {
+    vi.restoreAllMocks();
     vi.useRealTimers();
   });
 
@@ -128,6 +130,29 @@ describe("JarDetailPage", () => {
     fireEvent.click(button);
 
     expect(getStoredStorage().jars[0].marbles).toHaveLength(3);
+  });
+
+  it("hides the streak badge when the computed streak is invalid", () => {
+    vi.spyOn(streak, "computeStreak").mockReturnValue(Number.NaN);
+    seedStorage([
+      {
+        id: "jar-1",
+        name: "Morning walk",
+        target: 10,
+        color: "coral",
+        marbles: [
+          { date: "2026-06-07", at: "2026-06-07T12:00:00.000Z" },
+          { date: "2026-06-08", at: "2026-06-08T12:00:00.000Z" },
+          { date: "2026-06-09", at: "2026-06-09T12:00:00.000Z" },
+        ],
+        createdAt: "2026-06-01T12:00:00.000Z",
+      },
+    ]);
+
+    render(<JarDetailPage />);
+
+    expect(screen.queryByText("NaN days in a row 🔥")).not.toBeInTheDocument();
+    expect(screen.queryByText(/days in a row/)).not.toBeInTheDocument();
   });
 
   it("shows a short drop message for a new streak", () => {
@@ -457,12 +482,12 @@ describe("JarDetailPage", () => {
       {
         id: "jar-1",
         name: "Daily reading",
-        target: 3,
+        target: 4,
         color: "mint",
         marbles: [
+          { date: "2026-06-06", at: "2026-06-06T12:00:00.000Z" },
           { date: "2026-06-07", at: "2026-06-07T12:00:00.000Z" },
           { date: "2026-06-08", at: "2026-06-08T12:00:00.000Z" },
-          { date: "2026-06-09", at: "2026-06-09T12:00:00.000Z" },
         ],
         createdAt: "2026-06-01T12:00:00.000Z",
       },

--- a/app/jar/page.tsx
+++ b/app/jar/page.tsx
@@ -325,6 +325,10 @@ export default function JarDetailPage() {
   );
   const isDoneToday = marbleDates.has(today);
   const streakCount = computeStreak(jar?.marbles ?? []);
+  const shouldShowStreakBadge =
+    Number.isFinite(streakCount) &&
+    Number.isInteger(streakCount) &&
+    streakCount >= 3;
 
   const handleAddToday = () => {
     if (!jar || isDoneToday || jar.completedAt) {
@@ -453,7 +457,7 @@ export default function JarDetailPage() {
               ✓ Complete
             </p>
           ) : null}
-          {streakCount >= 3 ? (
+          {shouldShowStreakBadge ? (
             <p className="mt-4 inline-flex rounded-full border border-butter/70 bg-butter/20 px-3 py-1 text-sm font-semibold text-ink">
               {streakCount} days in a row 🔥
             </p>

--- a/lib/streak.test.ts
+++ b/lib/streak.test.ts
@@ -61,6 +61,24 @@ describe("computeStreak", () => {
     expect(computeStreak(marbles)).toBe(3);
   });
 
+  it("returns a finite non-negative integer for malformed stored marbles", () => {
+    const streak = computeStreak([
+      "",
+      "legacy-id",
+      "2026-06-99",
+      {},
+      { date: undefined },
+      { date: null },
+      { date: Number.NaN },
+      { date: "not-a-date" },
+    ] as unknown as Marble[]);
+
+    expect(Number.isFinite(streak)).toBe(true);
+    expect(Number.isInteger(streak)).toBe(true);
+    expect(streak).toBeGreaterThanOrEqual(0);
+    expect(streak).toBe(0);
+  });
+
   it("returns 0 for marbles only from old dates", () => {
     expect(computeStreak(["2026-05-01", "2026-05-02"])).toBe(0);
   });

--- a/lib/streak.ts
+++ b/lib/streak.ts
@@ -8,8 +8,26 @@ function getDateKey(date: Date) {
   return date.toISOString().slice(0, 10);
 }
 
-function getMarbleDate(marble: Marble) {
-  return typeof marble === "string" ? marble : marble.date;
+function getMarbleDate(marble: unknown) {
+  if (typeof marble === "string") {
+    return marble;
+  }
+
+  if (marble && typeof marble === "object" && "date" in marble) {
+    const date = (marble as { date?: unknown }).date;
+
+    return typeof date === "string" ? date : "";
+  }
+
+  return "";
+}
+
+function normalizeStreakCount(streak: number) {
+  if (!Number.isFinite(streak)) {
+    return 0;
+  }
+
+  return Math.max(0, Math.floor(streak));
 }
 
 function shiftDateKey(dateKey: string, offsetDays: number) {
@@ -35,5 +53,5 @@ export function computeStreak(marbles: Marble[]): number {
     cursorDate = shiftDateKey(cursorDate, -1);
   }
 
-  return streak;
+  return normalizeStreakCount(streak);
 }


### PR DESCRIPTION
## Summary
- Hardened streak date extraction and normalized computed streak counts to finite, non-negative integers.
- Added an explicit finite/integer guard before rendering the jar detail streak badge.
- Added regression tests for malformed stored marble data and invalid badge counts.

## Test Plan
- pnpm test -- lib/streak.test.ts app/jar/__tests__/page.test.tsx
- pnpm tsc --noEmit
- pnpm build

## Notes
- This repository does not have a remote develop branch, so this PR targets main.

Closes #26