### PR TITLE
Establish ST1 design foundation

### DIFF
--- a/app/components/ui/badge.tsx
+++ b/app/components/ui/badge.tsx
@@ -1,0 +1,28 @@
+import type { ComponentProps } from "react";
+
+import { cn } from "../../../lib/cn";
+
+export type BadgeTone = "success" | "streak" | "neutral";
+
+const toneClasses: Record<BadgeTone, string> = {
+  success: "border-mint/70 bg-mint/20 text-ink",
+  streak: "border-butter/70 bg-butter/20 text-ink",
+  neutral: "border-line bg-cream text-ink",
+};
+
+export function Badge({
+  tone = "neutral",
+  className,
+  ...props
+}: ComponentProps<"span"> & { tone?: BadgeTone }) {
+  return (
+    <span
+      className={cn(
+        "inline-flex items-center gap-1 rounded-full border px-3 py-1 text-xs font-semibold shadow-sm",
+        toneClasses[tone],
+        className,
+      )}
+      {...props}
+    />
+  );
+}

--- a/app/components/ui/button.tsx
+++ b/app/components/ui/button.tsx
@@ -1,0 +1,56 @@
+import type { ComponentProps } from "react";
+
+import { cn } from "../../../lib/cn";
+
+export type ButtonVariant = "primary" | "secondary" | "ghost";
+export type ButtonSize = "sm" | "md" | "lg";
+
+const baseClasses =
+  "inline-flex items-center justify-center rounded-lg font-semibold shadow-sm transition " +
+  "focus:outline-none focus:ring-2 focus:ring-ink focus:ring-offset-2 focus:ring-offset-cream " +
+  "disabled:cursor-not-allowed";
+
+const variantClasses: Record<ButtonVariant, string> = {
+  primary: "bg-ink text-cream hover:bg-soft-ink disabled:bg-soft-ink/45",
+  secondary: "border border-line bg-white text-ink hover:border-soft-ink",
+  ghost: "text-ink hover:bg-line/40",
+};
+
+const sizeClasses: Record<ButtonSize, string> = {
+  sm: "px-4 py-2 text-sm",
+  md: "px-5 py-3 text-sm",
+  lg: "px-5 py-4 text-base",
+};
+
+export function buttonClasses({
+  variant = "primary",
+  size = "md",
+  className,
+}: {
+  variant?: ButtonVariant;
+  size?: ButtonSize;
+  className?: string;
+} = {}): string {
+  return cn(baseClasses, variantClasses[variant], sizeClasses[size], className);
+}
+
+type ButtonProps = ComponentProps<"button"> & {
+  variant?: ButtonVariant;
+  size?: ButtonSize;
+};
+
+export function Button({
+  variant = "primary",
+  size = "md",
+  className,
+  type = "button",
+  ...props
+}: ButtonProps) {
+  return (
+    <button
+      className={buttonClasses({ variant, size, className })}
+      type={type}
+      {...props}
+    />
+  );
+}

--- a/app/components/ui/card.tsx
+++ b/app/components/ui/card.tsx
@@ -1,0 +1,11 @@
+import type { ComponentProps } from "react";
+
+import { cn } from "../../../lib/cn";
+
+export function cardClasses(className?: string): string {
+  return cn("rounded-lg border border-line bg-white shadow-sm", className);
+}
+
+export function Card({ className, ...props }: ComponentProps<"div">) {
+  return <div className={cardClasses(className)} {...props} />;
+}

--- a/app/components/ui/field.tsx
+++ b/app/components/ui/field.tsx
@@ -1,0 +1,27 @@
+import type { ReactNode } from "react";
+
+export function Field({
+  label,
+  htmlFor,
+  error,
+  children,
+}: {
+  label: string;
+  htmlFor: string;
+  error?: string;
+  children: ReactNode;
+}) {
+  return (
+    <div>
+      <label className="block text-sm font-semibold text-ink" htmlFor={htmlFor}>
+        {label}
+      </label>
+      <div className="mt-2">{children}</div>
+      {error ? (
+        <p className="mt-2 text-sm font-medium text-coral" id={`${htmlFor}-error`}>
+          {error}
+        </p>
+      ) : null}
+    </div>
+  );
+}

--- a/app/components/ui/index.ts
+++ b/app/components/ui/index.ts
@@ -1,0 +1,5 @@
+export { Badge, type BadgeTone } from "./badge";
+export { Button, buttonClasses, type ButtonSize, type ButtonVariant } from "./button";
+export { Card, cardClasses } from "./card";
+export { Field } from "./field";
+export { Input } from "./input";

--- a/app/components/ui/input.tsx
+++ b/app/components/ui/input.tsx
@@ -1,0 +1,16 @@
+import type { ComponentProps } from "react";
+
+import { cn } from "../../../lib/cn";
+
+export function Input({ className, ...props }: ComponentProps<"input">) {
+  return (
+    <input
+      className={cn(
+        "w-full rounded-lg border border-line bg-white px-4 py-3 text-base text-ink",
+        "shadow-sm outline-none transition focus:border-ink focus:ring-2 focus:ring-mint/40",
+        className,
+      )}
+      {...props}
+    />
+  );
+}

--- a/app/components/ui/input.tsx
+++ b/app/components/ui/input.tsx
@@ -6,7 +6,7 @@ export function Input({ className, ...props }: ComponentProps<"input">) {
   return (
     <input
       className={cn(
-        "w-full rounded-lg border border-line bg-white px-4 py-3 text-base text-ink",
+        "rounded-lg border border-line bg-white px-4 py-3 text-base text-ink",
         "shadow-sm outline-none transition focus:border-ink focus:ring-2 focus:ring-mint/40",
         className,
       )}

--- a/app/globals.css
+++ b/app/globals.css
@@ -14,6 +14,24 @@
   --ink: #31261f;
   --soft-ink: #7c6a5f;
   --line: #eadfd2;
+
+  /* Lighter and deeper companion steps for the pastel marble palette. */
+  --coral-tint: color-mix(in srgb, var(--coral) 55%, white);
+  --coral-shade: color-mix(in srgb, var(--coral) 80%, var(--ink));
+  --mint-tint: color-mix(in srgb, var(--mint) 55%, white);
+  --mint-shade: color-mix(in srgb, var(--mint) 80%, var(--ink));
+  --lavender-tint: color-mix(in srgb, var(--lavender) 55%, white);
+  --lavender-shade: color-mix(in srgb, var(--lavender) 80%, var(--ink));
+  --butter-tint: color-mix(in srgb, var(--butter) 55%, white);
+  --butter-shade: color-mix(in srgb, var(--butter) 80%, var(--ink));
+  --sky-tint: color-mix(in srgb, var(--sky) 55%, white);
+  --sky-shade: color-mix(in srgb, var(--sky) 80%, var(--ink));
+  --peach-tint: color-mix(in srgb, var(--peach) 55%, white);
+  --peach-shade: color-mix(in srgb, var(--peach) 80%, var(--ink));
+  --lilac-tint: color-mix(in srgb, var(--lilac) 55%, white);
+  --lilac-shade: color-mix(in srgb, var(--lilac) 80%, var(--ink));
+  --sage-tint: color-mix(in srgb, var(--sage) 55%, white);
+  --sage-shade: color-mix(in srgb, var(--sage) 80%, var(--ink));
 }
 
 @theme inline {
@@ -30,10 +48,21 @@
   --color-ink: var(--ink);
   --color-soft-ink: var(--soft-ink);
   --color-line: var(--line);
-  --font-sans:
-    "Avenir Next", "Segoe UI", "Helvetica Neue", Arial, sans-serif;
-  --font-heading:
-    "Iowan Old Style", "Palatino Linotype", "Book Antiqua", Georgia, serif;
+  --font-sans: var(--font-inter), "Segoe UI", "Helvetica Neue", Arial, sans-serif;
+  --font-heading: var(--font-fraunces), "Palatino Linotype", "Book Antiqua", Georgia, serif;
+
+  /* Additive layout vocabulary for later redesign stages. */
+  --spacing-layout-xs: 0.5rem;
+  --spacing-layout-sm: 1rem;
+  --spacing-layout-md: 1.25rem;
+  --spacing-layout-lg: 2rem;
+  --spacing-layout-xl: 3rem;
+  --radius-control: 0.5rem;
+  --radius-card: 0.75rem;
+  --radius-panel: 1rem;
+  --radius-pill: 9999px;
+  --shadow-warm-sm: 0 1px 2px color-mix(in srgb, var(--ink) 8%, transparent);
+  --shadow-warm-md: 0 8px 24px color-mix(in srgb, var(--ink) 6%, transparent);
 }
 
 @layer base {

--- a/app/jar/__tests__/page.test.tsx
+++ b/app/jar/__tests__/page.test.tsx
@@ -81,7 +81,7 @@ describe("JarDetailPage", () => {
     expect(
       screen.getByRole("img", { name: "Daily reading jar is 60% full" }),
     ).toBeInTheDocument();
-    expect(screen.getByText("Keep going")).toBeInTheDocument();
+    expect(screen.queryByText("Keep going")).not.toBeInTheDocument();
     expect(getStoredStorage()).toEqual({
       jars: [
         {
@@ -163,60 +163,6 @@ describe("JarDetailPage", () => {
       expect(screen.queryByText(/days in a row/)).not.toBeInTheDocument();
     },
   );
-
-  it("shows a short drop message for a new streak", () => {
-    seedStorage([
-      {
-        id: "jar-1",
-        name: "Daily reading",
-        target: 5,
-        color: "mint",
-        marbles: [],
-        createdAt: "2026-06-01T12:00:00.000Z",
-      },
-    ]);
-
-    render(<JarDetailPage />);
-
-    expect(screen.queryByText("Nice!")).not.toBeInTheDocument();
-
-    fireEvent.click(
-      screen.getByRole("button", { name: "Add today's marble" }),
-    );
-
-    expect(screen.getByText("Nice!")).toBeInTheDocument();
-  });
-
-  it("shows the streak milestone in the drop message", () => {
-    seedStorage([
-      {
-        id: "jar-1",
-        name: "Daily reading",
-        target: 14,
-        color: "mint",
-        marbles: [
-          { date: "2026-05-31", at: "2026-05-31T12:00:00.000Z" },
-          { date: "2026-06-01", at: "2026-06-01T12:00:00.000Z" },
-          { date: "2026-06-02", at: "2026-06-02T12:00:00.000Z" },
-          { date: "2026-06-03", at: "2026-06-03T12:00:00.000Z" },
-          { date: "2026-06-04", at: "2026-06-04T12:00:00.000Z" },
-          { date: "2026-06-05", at: "2026-06-05T12:00:00.000Z" },
-          { date: "2026-06-06", at: "2026-06-06T12:00:00.000Z" },
-          { date: "2026-06-07", at: "2026-06-07T12:00:00.000Z" },
-          { date: "2026-06-08", at: "2026-06-08T12:00:00.000Z" },
-        ],
-        createdAt: "2026-06-01T12:00:00.000Z",
-      },
-    ]);
-
-    render(<JarDetailPage />);
-
-    fireEvent.click(
-      screen.getByRole("button", { name: "Add today's marble" }),
-    );
-
-    expect(screen.getByText("10 in a row!")).toBeInTheDocument();
-  });
 
   it("renders the last 14 days with filled, missed, and today-pending states", () => {
     seedStorage([

--- a/app/jar/page.tsx
+++ b/app/jar/page.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import Link from "next/link";
-import { AnimatePresence, motion, useReducedMotion } from "framer-motion";
 import { useEffect, useMemo, useRef, useState } from "react";
 
 import { CelebrationModal } from "../components/celebration-modal";
@@ -18,11 +17,6 @@ import {
 import { computeStreak } from "../../lib/streak";
 
 const CELEBRATION_DELAY_MS = 650;
-
-type DropCue = {
-  marbleKey: string;
-  message: string;
-};
 
 function getTodayDate() {
   return new Date().toISOString().slice(0, 10);
@@ -63,18 +57,6 @@ function getFillPercent(jar: Jar) {
   return Math.min(100, Math.round((jar.marbles.length / jar.target) * 100));
 }
 
-function getDropMessage(streakCount: number) {
-  if (streakCount >= 10) {
-    return `${streakCount} in a row!`;
-  }
-
-  if (streakCount >= 3) {
-    return "Keep going";
-  }
-
-  return "Nice!";
-}
-
 function getLastFourteenDays(today: string) {
   return Array.from({ length: 14 }, (_, index) => shiftDate(today, index - 13));
 }
@@ -109,8 +91,7 @@ function NotFoundState() {
   );
 }
 
-function LargeJar({ dropCue, jar }: { dropCue: DropCue | null; jar: Jar }) {
-  const shouldReduceMotion = useReducedMotion();
+function LargeJar({ jar }: { jar: Jar }) {
   const colorStyles = getJarColor(jar.color);
   const fillPercent = getFillPercent(jar);
   const previewMarbles = jar.marbles.slice(-24);
@@ -121,22 +102,6 @@ function LargeJar({ dropCue, jar }: { dropCue: DropCue | null; jar: Jar }) {
       className="relative mx-auto h-[430px] w-full max-w-[340px] sm:h-[500px] sm:max-w-[400px]"
       role="img"
     >
-      <AnimatePresence>
-        {dropCue ? (
-          <motion.div
-            animate={{ opacity: 1, y: 0 }}
-            aria-live="polite"
-            className="pointer-events-none absolute -top-2 left-0 right-0 z-20 flex justify-center"
-            exit={{ opacity: 0, y: shouldReduceMotion ? 0 : -8 }}
-            initial={{ opacity: 0, y: shouldReduceMotion ? 0 : 8 }}
-            transition={{ duration: shouldReduceMotion ? 0 : 0.18 }}
-          >
-            <p className="rounded-full bg-white/95 px-3 py-1 text-sm font-semibold text-ink shadow-sm ring-1 ring-line">
-              {dropCue.message}
-            </p>
-          </motion.div>
-        ) : null}
-      </AnimatePresence>
       <div className="absolute left-1/2 top-0 h-10 w-40 -translate-x-1/2 rounded-t-lg border-4 border-ink/75 bg-glass" />
       <div className="absolute left-1/2 top-9 h-12 w-56 -translate-x-1/2 rounded-xl border-4 border-ink/75 bg-glass" />
       <div className="absolute bottom-0 left-1/2 h-[370px] w-full -translate-x-1/2 overflow-hidden rounded-b-[4rem] rounded-t-[2rem] border-4 border-ink/75 bg-white/60 shadow-inner sm:h-[430px]">
@@ -144,41 +109,21 @@ function LargeJar({ dropCue, jar }: { dropCue: DropCue | null; jar: Jar }) {
           className={`absolute bottom-0 left-0 w-full transition-all ${colorStyles.fill}`}
           style={{ height: `${fillPercent}%` }}
         />
-        <motion.div
+        <div
           aria-hidden="true"
           className="absolute inset-x-10 bottom-8 grid grid-cols-4 gap-3 sm:grid-cols-6"
-          layout
         >
           {previewMarbles.map((marble, index) => {
             const marbleKey = getMarbleKey(marble, index);
-            const isDropping = dropCue?.marbleKey === marbleKey;
 
             return (
-              <motion.span
-                animate={{ scale: 1, y: 0 }}
+              <span
                 className={`h-8 w-8 rounded-full shadow-sm ring-2 ring-white/80 ${colorStyles.solid}`}
-                initial={
-                  isDropping && !shouldReduceMotion
-                    ? { scale: 0.95, y: -40 }
-                    : false
-                }
                 key={marbleKey}
-                layout
-                transition={
-                  isDropping && !shouldReduceMotion
-                    ? {
-                        bounce: 0.32,
-                        damping: 14,
-                        duration: 0.6,
-                        stiffness: 360,
-                        type: "spring",
-                      }
-                    : { duration: 0 }
-                }
               />
             );
           })}
-        </motion.div>
+        </div>
       </div>
     </div>
   );
@@ -237,10 +182,8 @@ export default function JarDetailPage() {
   const [jarId, setJarId] = useState("");
   const [jar, setJar] = useState<Jar | null>(null);
   const [hasLoaded, setHasLoaded] = useState(false);
-  const [dropCue, setDropCue] = useState<DropCue | null>(null);
   const [isCelebrating, setIsCelebrating] = useState(false);
   const celebrationTimerRef = useRef<number | null>(null);
-  const dropCueTimerRef = useRef<number | null>(null);
   const today = getTodayDate();
 
   useEffect(() => {
@@ -256,10 +199,6 @@ export default function JarDetailPage() {
     return () => {
       if (celebrationTimerRef.current) {
         window.clearTimeout(celebrationTimerRef.current);
-      }
-
-      if (dropCueTimerRef.current) {
-        window.clearTimeout(dropCueTimerRef.current);
       }
     };
   }, []);
@@ -303,19 +242,6 @@ export default function JarDetailPage() {
       jars: updatedJars,
     });
     setJar(updatedJar);
-    setDropCue({
-      marbleKey: getMarbleKey(newMarble, updatedMarbles.length - 1),
-      message: getDropMessage(computeStreak(updatedMarbles)),
-    });
-
-    if (dropCueTimerRef.current) {
-      window.clearTimeout(dropCueTimerRef.current);
-    }
-
-    dropCueTimerRef.current = window.setTimeout(() => {
-      setDropCue(null);
-      dropCueTimerRef.current = null;
-    }, CELEBRATION_DELAY_MS);
 
     if (justCompleted) {
       celebrationTimerRef.current = window.setTimeout(() => {
@@ -392,7 +318,7 @@ export default function JarDetailPage() {
             cn(colorStyles.border, colorStyles.tint, "px-5 py-8"),
           )}
         >
-          <LargeJar dropCue={dropCue} jar={jar} />
+          <LargeJar jar={jar} />
         </aside>
 
         <div>

--- a/app/jar/page.tsx
+++ b/app/jar/page.tsx
@@ -5,6 +5,9 @@ import { AnimatePresence, motion, useReducedMotion } from "framer-motion";
 import { useEffect, useMemo, useRef, useState } from "react";
 
 import { CelebrationModal } from "../components/celebration-modal";
+import { Badge, Button, buttonClasses, Card, cardClasses } from "../components/ui";
+import { cn } from "../../lib/cn";
+import { getJarColor } from "../../lib/jar-colors";
 import {
   findJarById,
   type Jar,
@@ -20,64 +23,6 @@ type DropCue = {
   marbleKey: string;
   message: string;
 };
-
-const jarColorStyles = {
-  coral: {
-    fill: "bg-coral/35",
-    dot: "bg-coral",
-    border: "border-coral/70",
-    tint: "bg-coral/10",
-  },
-  mint: {
-    fill: "bg-mint/35",
-    dot: "bg-mint",
-    border: "border-mint/70",
-    tint: "bg-mint/10",
-  },
-  lavender: {
-    fill: "bg-lavender/35",
-    dot: "bg-lavender",
-    border: "border-lavender/70",
-    tint: "bg-lavender/10",
-  },
-  butter: {
-    fill: "bg-butter/45",
-    dot: "bg-butter",
-    border: "border-butter/70",
-    tint: "bg-butter/15",
-  },
-  sky: {
-    fill: "bg-sky/35",
-    dot: "bg-sky",
-    border: "border-sky/70",
-    tint: "bg-sky/10",
-  },
-  peach: {
-    fill: "bg-peach/35",
-    dot: "bg-peach",
-    border: "border-peach/70",
-    tint: "bg-peach/10",
-  },
-  lilac: {
-    fill: "bg-lilac/35",
-    dot: "bg-lilac",
-    border: "border-lilac/70",
-    tint: "bg-lilac/10",
-  },
-  sage: {
-    fill: "bg-sage/35",
-    dot: "bg-sage",
-    border: "border-sage/70",
-    tint: "bg-sage/10",
-  },
-} as const;
-
-function getJarColorStyles(color: string) {
-  return (
-    jarColorStyles[color as keyof typeof jarColorStyles] ??
-    jarColorStyles.coral
-  );
-}
 
 function getTodayDate() {
   return new Date().toISOString().slice(0, 10);
@@ -155,7 +100,7 @@ function NotFoundState() {
         This jar is not saved in this browser.
       </p>
       <Link
-        className="mt-8 rounded-lg bg-ink px-5 py-3 text-sm font-semibold text-cream shadow-sm transition hover:bg-soft-ink focus:outline-none focus:ring-2 focus:ring-ink focus:ring-offset-2 focus:ring-offset-cream"
+        className={cn("mt-8", buttonClasses())}
         href="/"
       >
         Back to jars
@@ -166,7 +111,7 @@ function NotFoundState() {
 
 function LargeJar({ dropCue, jar }: { dropCue: DropCue | null; jar: Jar }) {
   const shouldReduceMotion = useReducedMotion();
-  const colorStyles = getJarColorStyles(jar.color);
+  const colorStyles = getJarColor(jar.color);
   const fillPercent = getFillPercent(jar);
   const previewMarbles = jar.marbles.slice(-24);
 
@@ -211,7 +156,7 @@ function LargeJar({ dropCue, jar }: { dropCue: DropCue | null; jar: Jar }) {
             return (
               <motion.span
                 animate={{ scale: 1, y: 0 }}
-                className={`h-8 w-8 rounded-full shadow-sm ring-2 ring-white/80 ${colorStyles.dot}`}
+                className={`h-8 w-8 rounded-full shadow-sm ring-2 ring-white/80 ${colorStyles.solid}`}
                 initial={
                   isDropping && !shouldReduceMotion
                     ? { scale: 0.95, y: -40 }
@@ -248,7 +193,7 @@ function HistoryGrid({
   today: string;
   color: string;
 }) {
-  const colorStyles = getJarColorStyles(color);
+  const colorStyles = getJarColor(color);
   const days = getLastFourteenDays(today);
 
   return (
@@ -272,7 +217,7 @@ function HistoryGrid({
               aria-label={label}
               className={`flex h-11 w-11 items-center justify-center rounded-full border text-xl font-semibold shadow-sm ${
                 hasMarble
-                  ? `${colorStyles.dot} border-transparent text-white`
+                  ? `${colorStyles.solid} border-transparent text-white`
                   : "border-line bg-white text-soft-ink"
               }`}
               key={date}
@@ -427,7 +372,7 @@ export default function JarDetailPage() {
     return <NotFoundState />;
   }
 
-  const colorStyles = getJarColorStyles(jar.color);
+  const colorStyles = getJarColor(jar.color);
   const fillPercent = getFillPercent(jar);
   const isCompleted = Boolean(jar.completedAt);
   const isFull = jar.marbles.length >= jar.target;
@@ -435,7 +380,7 @@ export default function JarDetailPage() {
   return (
     <section className="mx-auto min-h-[calc(100vh-88px)] w-full max-w-6xl px-5 pb-16 pt-6">
       <Link
-        className="inline-flex rounded-lg border border-line bg-white px-4 py-2 text-sm font-semibold text-ink shadow-sm transition hover:border-soft-ink focus:outline-none focus:ring-2 focus:ring-ink focus:ring-offset-2 focus:ring-offset-cream"
+        className={buttonClasses({ variant: "secondary", size: "sm" })}
         href="/"
       >
         Back
@@ -443,7 +388,9 @@ export default function JarDetailPage() {
 
       <div className="mt-6 grid gap-8 lg:grid-cols-[minmax(0,400px)_minmax(0,1fr)] lg:items-center">
         <aside
-          className={`rounded-lg border ${colorStyles.border} ${colorStyles.tint} px-5 py-8 shadow-sm`}
+          className={cardClasses(
+            cn(colorStyles.border, colorStyles.tint, "px-5 py-8"),
+          )}
         >
           <LargeJar dropCue={dropCue} jar={jar} />
         </aside>
@@ -453,14 +400,14 @@ export default function JarDetailPage() {
             {jar.name}
           </h1>
           {isCompleted ? (
-            <p className="mt-4 inline-flex rounded-full border border-mint/70 bg-mint/20 px-3 py-1 text-sm font-semibold text-ink">
+            <Badge tone="success" className="mt-4 px-3 text-sm">
               ✓ Complete
-            </p>
+            </Badge>
           ) : null}
           {shouldShowStreakBadge ? (
-            <p className="mt-4 inline-flex rounded-full border border-butter/70 bg-butter/20 px-3 py-1 text-sm font-semibold text-ink">
+            <Badge tone="streak" className="mt-4 px-3 text-sm">
               {streakCount} days in a row 🔥
-            </p>
+            </Badge>
           ) : null}
           <p className="mt-5 text-xl font-semibold text-ink">
             {jar.marbles.length} / {jar.target} marbles
@@ -469,39 +416,38 @@ export default function JarDetailPage() {
             {fillPercent}% full
           </p>
           {isCompleted ? (
-            <div className="mt-8 rounded-lg border border-line bg-white/75 p-5 shadow-sm">
+            <Card className="mt-8 bg-white/75 p-5">
               <p className="font-heading text-2xl font-semibold text-ink">
                 Complete
               </p>
               <p className="mt-2 max-w-xl text-sm leading-6 text-soft-ink">
                 This jar is finished and saved with its full stack of marbles.
               </p>
-            </div>
+            </Card>
           ) : isFull ? (
-            <div className="mt-8 rounded-lg border border-line bg-white/75 p-5 shadow-sm">
+            <Card className="mt-8 bg-white/75 p-5">
               <p className="font-heading text-2xl font-semibold text-ink">
                 Jar full
               </p>
               <p className="mt-2 max-w-xl text-sm leading-6 text-soft-ink">
                 Choose where this completed jar should live.
               </p>
-              <button
-                className="mt-5 rounded-lg bg-ink px-5 py-3 text-sm font-semibold text-cream shadow-sm transition hover:bg-soft-ink focus:outline-none focus:ring-2 focus:ring-ink focus:ring-offset-2 focus:ring-offset-cream"
+              <Button
+                className="mt-5"
                 onClick={() => setIsCelebrating(true)}
-                type="button"
               >
                 Finish this jar
-              </button>
-            </div>
+              </Button>
+            </Card>
           ) : (
-            <button
-              className="mt-8 w-full rounded-lg bg-ink px-5 py-4 text-base font-semibold text-cream shadow-sm transition hover:bg-soft-ink focus:outline-none focus:ring-2 focus:ring-ink focus:ring-offset-2 focus:ring-offset-cream disabled:cursor-not-allowed disabled:bg-soft-ink/45 sm:w-auto"
+            <Button
+              className="mt-8 w-full sm:w-auto"
               disabled={isDoneToday}
               onClick={handleAddToday}
-              type="button"
+              size="lg"
             >
               {isDoneToday ? "Done for today ✓" : "Add today's marble"}
-            </button>
+            </Button>
           )}
         </div>
       </div>

--- a/app/jars/new/__tests__/page.test.tsx
+++ b/app/jars/new/__tests__/page.test.tsx
@@ -100,4 +100,12 @@ describe("NewJarPage", () => {
 
     expect(screen.getByLabelText("Sage jar preview")).toBeInTheDocument();
   });
+
+  it("keeps the target input narrow while the name input fills the field", () => {
+    render(<NewJarPage />);
+
+    expect(screen.getByLabelText("Name")).toHaveClass("w-full");
+    expect(screen.getByLabelText("Target")).toHaveClass("w-36");
+    expect(screen.getByLabelText("Target")).not.toHaveClass("w-full");
+  });
 });

--- a/app/jars/new/page.tsx
+++ b/app/jars/new/page.tsx
@@ -4,99 +4,38 @@ import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { type FormEvent, useMemo, useState } from "react";
 
+import {
+  Button,
+  buttonClasses,
+  cardClasses,
+  Field,
+  Input,
+} from "../../components/ui";
+import { cn } from "../../../lib/cn";
+import { type JarColorStyle, jarColorList } from "../../../lib/jar-colors";
 import { type Jar, loadJars, saveJars } from "../../../lib/storage";
-
-type MarbleColor = {
-  name: string;
-  value: string;
-  swatchClass: string;
-  jarFillClass: string;
-  borderClass: string;
-  previewClass: string;
-};
-
-const marbleColors: MarbleColor[] = [
-  {
-    name: "Coral",
-    value: "coral",
-    swatchClass: "bg-coral",
-    jarFillClass: "bg-coral/30",
-    borderClass: "border-coral/70",
-    previewClass: "bg-coral/20",
-  },
-  {
-    name: "Mint",
-    value: "mint",
-    swatchClass: "bg-mint",
-    jarFillClass: "bg-mint/30",
-    borderClass: "border-mint/70",
-    previewClass: "bg-mint/20",
-  },
-  {
-    name: "Lavender",
-    value: "lavender",
-    swatchClass: "bg-lavender",
-    jarFillClass: "bg-lavender/30",
-    borderClass: "border-lavender/70",
-    previewClass: "bg-lavender/20",
-  },
-  {
-    name: "Butter",
-    value: "butter",
-    swatchClass: "bg-butter",
-    jarFillClass: "bg-butter/30",
-    borderClass: "border-butter/70",
-    previewClass: "bg-butter/20",
-  },
-  {
-    name: "Sky",
-    value: "sky",
-    swatchClass: "bg-sky",
-    jarFillClass: "bg-sky/30",
-    borderClass: "border-sky/70",
-    previewClass: "bg-sky/20",
-  },
-  {
-    name: "Peach",
-    value: "peach",
-    swatchClass: "bg-peach",
-    jarFillClass: "bg-peach/30",
-    borderClass: "border-peach/70",
-    previewClass: "bg-peach/20",
-  },
-  {
-    name: "Lilac",
-    value: "lilac",
-    swatchClass: "bg-lilac",
-    jarFillClass: "bg-lilac/30",
-    borderClass: "border-lilac/70",
-    previewClass: "bg-lilac/20",
-  },
-  {
-    name: "Sage",
-    value: "sage",
-    swatchClass: "bg-sage",
-    jarFillClass: "bg-sage/30",
-    borderClass: "border-sage/70",
-    previewClass: "bg-sage/20",
-  },
-];
 
 function createJarId() {
   return globalThis.crypto?.randomUUID?.() ?? `jar-${Date.now()}`;
 }
 
-function JarPreview({ color }: { color: MarbleColor }) {
+function JarPreview({ color }: { color: JarColorStyle }) {
   return (
     <aside
-      className={`flex min-h-[320px] flex-col items-center justify-center rounded-lg border-2 ${color.borderClass} ${color.previewClass} px-8 py-10 text-center shadow-sm`}
-      aria-label={`${color.name} jar preview`}
+      className={cardClasses(
+        cn(
+          "flex min-h-[320px] flex-col items-center justify-center border-2 px-8 py-10 text-center",
+          color.border,
+          color.preview,
+        ),
+      )}
+      aria-label={`${color.label} jar preview`}
     >
       <div className="relative h-52 w-40">
         <div className="absolute left-1/2 top-0 h-7 w-20 -translate-x-1/2 rounded-t-md border-2 border-ink/75 bg-glass" />
         <div className="absolute left-1/2 top-6 h-6 w-24 -translate-x-1/2 rounded-md border-2 border-ink/75 bg-glass" />
         <div
-          className={`absolute bottom-0 left-1/2 h-40 w-32 -translate-x-1/2 rounded-b-[2rem] rounded-t-xl border-2 border-ink/75 ${color.jarFillClass} shadow-inner`}
+          className={`absolute bottom-0 left-1/2 h-40 w-32 -translate-x-1/2 rounded-b-[2rem] rounded-t-xl border-2 border-ink/75 ${color.jarFill} shadow-inner`}
         />
       </div>
       <p className="mt-5 text-sm font-medium text-soft-ink">Empty jar</p>
@@ -108,14 +47,14 @@ export default function NewJarPage() {
   const router = useRouter();
   const [name, setName] = useState("");
   const [target, setTarget] = useState("30");
-  const [color, setColor] = useState(marbleColors[0].value);
+  const [color, setColor] = useState(jarColorList[0].key);
   const [nameError, setNameError] = useState("");
   const [targetError, setTargetError] = useState("");
 
   const selectedColor = useMemo(
     () =>
-      marbleColors.find((marbleColor) => marbleColor.value === color) ??
-      marbleColors[0],
+      jarColorList.find((marbleColor) => marbleColor.key === color) ??
+      jarColorList[0],
     [color],
   );
 
@@ -160,17 +99,10 @@ export default function NewJarPage() {
           Create a jar
         </h1>
         <form className="mt-8 space-y-7" noValidate onSubmit={handleSubmit}>
-          <div>
-            <label
-              className="block text-sm font-semibold text-ink"
-              htmlFor="jar-name"
-            >
-              Name
-            </label>
-            <input
+          <Field error={nameError} htmlFor="jar-name" label="Name">
+            <Input
               aria-describedby={nameError ? "jar-name-error" : undefined}
               aria-invalid={nameError ? "true" : "false"}
-              className="mt-2 w-full rounded-lg border border-line bg-white px-4 py-3 text-base text-ink shadow-sm outline-none transition focus:border-ink focus:ring-2 focus:ring-mint/40"
               id="jar-name"
               maxLength={60}
               onChange={(event) => {
@@ -184,27 +116,13 @@ export default function NewJarPage() {
               type="text"
               value={name}
             />
-            {nameError ? (
-              <p
-                className="mt-2 text-sm font-medium text-coral"
-                id="jar-name-error"
-              >
-                {nameError}
-              </p>
-            ) : null}
-          </div>
+          </Field>
 
-          <div>
-            <label
-              className="block text-sm font-semibold text-ink"
-              htmlFor="jar-target"
-            >
-              Target
-            </label>
-            <input
+          <Field error={targetError} htmlFor="jar-target" label="Target">
+            <Input
               aria-describedby={targetError ? "jar-target-error" : undefined}
               aria-invalid={targetError ? "true" : "false"}
-              className="mt-2 w-36 rounded-lg border border-line bg-white px-4 py-3 text-base text-ink shadow-sm outline-none transition focus:border-ink focus:ring-2 focus:ring-mint/40"
+              className="w-36"
               id="jar-target"
               max={365}
               min={5}
@@ -217,52 +135,43 @@ export default function NewJarPage() {
               type="number"
               value={target}
             />
-            {targetError ? (
-              <p
-                className="mt-2 text-sm font-medium text-coral"
-                id="jar-target-error"
-              >
-                {targetError}
-              </p>
-            ) : null}
-          </div>
+          </Field>
 
           <fieldset>
             <legend className="text-sm font-semibold text-ink">Color</legend>
             <div className="mt-3 flex flex-wrap gap-3">
-              {marbleColors.map((marbleColor) => (
+              {jarColorList.map((marbleColor) => (
                 <label
                   className="group cursor-pointer rounded-full"
-                  key={marbleColor.value}
-                  title={marbleColor.name}
+                  key={marbleColor.key}
+                  title={marbleColor.label}
                 >
                   <input
-                    checked={color === marbleColor.value}
+                    checked={color === marbleColor.key}
                     className="peer sr-only"
                     name="color"
-                    onChange={() => setColor(marbleColor.value)}
+                    onChange={() => setColor(marbleColor.key)}
                     type="radio"
-                    value={marbleColor.value}
+                    value={marbleColor.key}
                   />
                   <span
-                    className={`block h-11 w-11 rounded-full border border-white/80 shadow-sm ring-offset-2 ring-offset-cream transition peer-checked:ring-2 peer-checked:ring-ink peer-focus-visible:ring-2 peer-focus-visible:ring-ink ${marbleColor.swatchClass}`}
+                    className={`block h-11 w-11 rounded-full border border-white/80 shadow-sm ring-offset-2 ring-offset-cream transition peer-checked:ring-2 peer-checked:ring-ink peer-focus-visible:ring-2 peer-focus-visible:ring-ink ${marbleColor.solid}`}
                     aria-hidden="true"
                   />
-                  <span className="sr-only">{marbleColor.name}</span>
+                  <span className="sr-only">{marbleColor.label}</span>
                 </label>
               ))}
             </div>
           </fieldset>
 
           <div className="flex flex-wrap gap-3 pt-2">
-            <button
-              className="rounded-lg bg-ink px-5 py-3 text-sm font-semibold text-cream shadow-sm transition hover:bg-soft-ink focus:outline-none focus:ring-2 focus:ring-ink focus:ring-offset-2 focus:ring-offset-cream"
+            <Button
               type="submit"
             >
               Create jar
-            </button>
+            </Button>
             <Link
-              className="rounded-lg border border-line bg-white px-5 py-3 text-sm font-semibold text-ink shadow-sm transition hover:border-soft-ink focus:outline-none focus:ring-2 focus:ring-ink focus:ring-offset-2 focus:ring-offset-cream"
+              className={buttonClasses({ variant: "secondary" })}
               href="/"
             >
               Cancel

--- a/app/jars/new/page.tsx
+++ b/app/jars/new/page.tsx
@@ -103,6 +103,7 @@ export default function NewJarPage() {
             <Input
               aria-describedby={nameError ? "jar-name-error" : undefined}
               aria-invalid={nameError ? "true" : "false"}
+              className="w-full"
               id="jar-name"
               maxLength={60}
               onChange={(event) => {

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from "next";
+import { Fraunces, Inter } from "next/font/google";
 import type { ReactNode } from "react";
 
 import { Header } from "./components/header";
@@ -9,13 +10,27 @@ export const metadata: Metadata = {
   description: "A marble jar habit tracker.",
 };
 
+const inter = Inter({
+  subsets: ["latin"],
+  variable: "--font-inter",
+  display: "swap",
+});
+
+const fraunces = Fraunces({
+  subsets: ["latin"],
+  weight: ["400", "500", "600", "700"],
+  style: ["normal"],
+  variable: "--font-fraunces",
+  display: "swap",
+});
+
 type RootLayoutProps = {
   children: ReactNode;
 };
 
 export default function RootLayout({ children }: RootLayoutProps) {
   return (
-    <html lang="en">
+    <html className={`${inter.variable} ${fraunces.variable}`} lang="en">
       <body className="min-h-screen bg-cream font-sans text-ink antialiased">
         <Header />
         <main>{children}</main>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -3,77 +3,14 @@
 import Link from "next/link";
 import { useEffect, useState } from "react";
 
+import { Badge, buttonClasses, cardClasses } from "./components/ui";
+import { cn } from "../lib/cn";
+import {
+  getJarColor,
+  jarColorSolids,
+} from "../lib/jar-colors";
 import { type Jar, loadCompletedJars, loadJars } from "../lib/storage";
 import { computeStreak } from "../lib/streak";
-
-const emptyStateMarbleColors = [
-  "bg-coral",
-  "bg-mint",
-  "bg-lavender",
-  "bg-butter",
-  "bg-sky",
-  "bg-peach",
-  "bg-lilac",
-  "bg-sage",
-] as const;
-
-const jarColorStyles = {
-  coral: {
-    fill: "bg-coral/35",
-    dot: "bg-coral",
-    border: "border-coral/60",
-    tint: "bg-coral/10",
-  },
-  mint: {
-    fill: "bg-mint/35",
-    dot: "bg-mint",
-    border: "border-mint/60",
-    tint: "bg-mint/10",
-  },
-  lavender: {
-    fill: "bg-lavender/35",
-    dot: "bg-lavender",
-    border: "border-lavender/60",
-    tint: "bg-lavender/10",
-  },
-  butter: {
-    fill: "bg-butter/45",
-    dot: "bg-butter",
-    border: "border-butter/70",
-    tint: "bg-butter/15",
-  },
-  sky: {
-    fill: "bg-sky/35",
-    dot: "bg-sky",
-    border: "border-sky/60",
-    tint: "bg-sky/10",
-  },
-  peach: {
-    fill: "bg-peach/35",
-    dot: "bg-peach",
-    border: "border-peach/60",
-    tint: "bg-peach/10",
-  },
-  lilac: {
-    fill: "bg-lilac/35",
-    dot: "bg-lilac",
-    border: "border-lilac/60",
-    tint: "bg-lilac/10",
-  },
-  sage: {
-    fill: "bg-sage/35",
-    dot: "bg-sage",
-    border: "border-sage/60",
-    tint: "bg-sage/10",
-  },
-} as const;
-
-function getJarColorStyles(color: string) {
-  return (
-    jarColorStyles[color as keyof typeof jarColorStyles] ??
-    jarColorStyles.coral
-  );
-}
 
 function getFillPercent(jar: Jar) {
   if (jar.target <= 0) {
@@ -87,7 +24,7 @@ function EmptyState() {
   return (
     <section className="mx-auto flex min-h-[calc(100vh-88px)] w-full max-w-4xl flex-col items-center justify-center px-5 pb-16 text-center">
       <div className="mb-8 grid grid-cols-4 gap-2" aria-hidden="true">
-        {emptyStateMarbleColors.map((color) => (
+        {jarColorSolids.map((color) => (
           <span
             className={`h-5 w-5 rounded-full shadow-sm ring-1 ring-white/70 ${color}`}
             key={color}
@@ -102,7 +39,7 @@ function EmptyState() {
         time.
       </p>
       <Link
-        className="mt-8 rounded-lg bg-ink px-5 py-3 text-sm font-semibold text-cream shadow-sm transition hover:bg-soft-ink focus:outline-none focus:ring-2 focus:ring-ink focus:ring-offset-2 focus:ring-offset-cream"
+        className={cn("mt-8", buttonClasses())}
         href="/jars/new"
       >
         Create your first jar
@@ -112,7 +49,7 @@ function EmptyState() {
 }
 
 function MiniJar({ jar }: { jar: Jar }) {
-  const colorStyles = getJarColorStyles(jar.color);
+  const colorStyles = getJarColor(jar.color);
   const fillPercent = getFillPercent(jar);
   const previewMarbles = jar.marbles.slice(0, 12);
 
@@ -135,7 +72,7 @@ function MiniJar({ jar }: { jar: Jar }) {
         >
           {previewMarbles.map((marble, index) => (
             <span
-              className={`h-4 w-4 rounded-full shadow-sm ring-1 ring-white/80 ${colorStyles.dot}`}
+              className={`h-4 w-4 rounded-full shadow-sm ring-1 ring-white/80 ${colorStyles.solid}`}
               key={`${marble}-${index}`}
             />
           ))}
@@ -146,19 +83,25 @@ function MiniJar({ jar }: { jar: Jar }) {
 }
 
 function JarCard({ jar }: { jar: Jar }) {
-  const colorStyles = getJarColorStyles(jar.color);
+  const colorStyles = getJarColor(jar.color);
   const streakCount = computeStreak(jar.marbles);
 
   return (
     <Link
       aria-label={`Open ${jar.name}`}
-      className={`group relative flex min-h-72 flex-col items-center rounded-lg border ${colorStyles.border} ${colorStyles.tint} px-5 py-6 text-center shadow-sm transition hover:-translate-y-0.5 hover:shadow-md focus:outline-none focus:ring-2 focus:ring-ink focus:ring-offset-2 focus:ring-offset-cream`}
+      className={cardClasses(
+        cn(
+          "group relative flex min-h-72 flex-col items-center px-5 py-6 text-center transition hover:-translate-y-0.5 hover:shadow-md focus:outline-none focus:ring-2 focus:ring-ink focus:ring-offset-2 focus:ring-offset-cream",
+          colorStyles.borderSoft,
+          colorStyles.tint,
+        ),
+      )}
       href={`/jar?id=${encodeURIComponent(jar.id)}`}
     >
       {jar.completedAt ? (
-        <span className="absolute right-3 top-3 rounded-full border border-mint/70 bg-cream px-3 py-1 text-xs font-semibold text-ink shadow-sm">
+        <Badge tone="success" className="absolute right-3 top-3 bg-cream">
           ✓ Complete
-        </span>
+        </Badge>
       ) : null}
       <MiniJar jar={jar} />
       <h2 className="mt-5 w-full truncate font-heading text-2xl font-semibold text-ink">
@@ -168,13 +111,14 @@ function JarCard({ jar }: { jar: Jar }) {
         {jar.marbles.length} / {jar.target}
       </p>
       {streakCount >= 3 ? (
-        <p
+        <Badge
+          tone="streak"
           aria-label={`${streakCount} day streak`}
-          className="mt-3 inline-flex items-center gap-1 rounded-full border border-butter/70 bg-butter/20 px-2.5 py-1 text-xs font-semibold text-ink"
+          className="mt-3 px-2.5"
         >
           <span aria-hidden="true">🔥</span>
           <span>{streakCount}</span>
-        </p>
+        </Badge>
       ) : null}
     </Link>
   );
@@ -200,7 +144,10 @@ export default function Home() {
           Your jars
         </h1>
         <Link
-          className="fixed right-5 top-5 z-10 rounded-lg bg-ink px-4 py-3 text-sm font-semibold text-cream shadow-md transition hover:bg-soft-ink focus:outline-none focus:ring-2 focus:ring-ink focus:ring-offset-2 focus:ring-offset-cream"
+          className={buttonClasses({
+            size: "sm",
+            className: "fixed right-5 top-5 z-10 py-3 shadow-md",
+          })}
           href="/jars/new"
         >
           + New jar

--- a/docs/plans/issue-38-design-foundation.md
+++ b/docs/plans/issue-38-design-foundation.md
@@ -1,0 +1,574 @@
+# Implementation Plan — ST1: Design foundation (web fonts, tokens & shared UI primitives)
+
+Closes #38
+
+## Summary
+
+ST1 is the **foundation** stage of the Premium-cozy redesign epic (ST2–ST5 build on it).
+It does **not** redesign any screen. It establishes the design system and removes
+duplication so later stages are fast and consistent. Four pieces:
+
+1. **Web fonts via `next/font`** — load a display serif (Fraunces) for headings and a
+   neutral sans (Inter) for body, self-hosted via `next/font/google`, wired into the
+   Tailwind v4 theme (`--font-heading` / `--font-sans`) and `app/layout.tsx`.
+2. **Token refinement** in `app/globals.css` — keep the cream + pastel palette, but add a
+   consistent radius scale, a soft warm elevation token, and per-color tint/shade steps as
+   **additive** theme tokens (no restyle of existing screens — that is ST2–ST5).
+3. **Shared UI primitives** in a new `app/components/ui/` — `Button`, `Card`, `Badge`,
+   `Input` + `Field`, plus a tiny `cn()` class helper. Replace the hand-rolled, repeated
+   class strings on `app/page.tsx`, `app/jar/page.tsx`, `app/jars/new/page.tsx`.
+4. **Single `jarColors` source of truth** in a new `lib/jar-colors.ts` — one map consumed
+   everywhere; delete the three duplicated definitions.
+
+The hard constraint throughout: **no visual or behavioral regression** vs current screens,
+and `pnpm tsc`, `pnpm test`, `pnpm build` must all pass. This is a refactor + type-polish,
+not a redesign.
+
+## Scope and Assumptions
+
+In scope (and only this):
+- Add `next/font` heading + body fonts and wire the two CSS variables.
+- Add additive design tokens (radius, soft-warm shadow, per-color tint/shade) to
+  `@theme` in `globals.css` without changing any currently-rendered utility.
+- Create `app/components/ui/` primitives and `lib/cn.ts`.
+- Create `lib/jar-colors.ts` and migrate the three pages to it.
+- Migrate the button/card/badge/input/field class strings on the three named pages to the
+  primitives.
+
+Explicitly **out of scope** (do not touch — keeps blast radius small and avoids
+regressions; later stages own these):
+- `app/components/celebration-modal.tsx` and `app/components/header.tsx` — they contain
+  button/pill-like strings but are **not** in acceptance criterion #2's list of three
+  pages. Leave them as-is for ST2+.
+- Any layout, copy, spacing, or color change visible on screen. No screen redesign.
+- `lib/storage.ts`, `lib/streak.ts`, and all test files (tests are the regression net;
+  do not weaken them).
+
+Assumptions:
+- The project uses **relative imports** (no `@/` path alias in `tsconfig.json`); new
+  modules will be imported relatively, matching the existing style
+  (e.g. `../lib/storage`, `./components/ui/button`).
+- Tailwind v4 auto-detects source files, so full **literal** class strings moved into
+  `lib/jar-colors.ts` and `app/components/ui/*` are still scanned and generated. All color
+  classes must stay complete literals (e.g. `"bg-coral/35"`), never interpolated fragments.
+- `pnpm build` runs with network access at build time so `next/font/google` can fetch and
+  self-host Fraunces/Inter into the static export (`output: "export"` in `next.config.ts`).
+  Fonts are **not** yet in `pnpm-lock.yaml` because `next/font` downloads them at build, not
+  as an npm dependency — no new package is added.
+
+## Affected Areas
+
+New files:
+- `lib/cn.ts` — class-name join helper (no new dependency).
+- `lib/jar-colors.ts` — single jar-color source of truth.
+- `app/components/ui/button.tsx` — `Button` + `buttonClasses()`.
+- `app/components/ui/card.tsx` — `Card` + `cardClasses()`.
+- `app/components/ui/badge.tsx` — `Badge`.
+- `app/components/ui/input.tsx` — `Input`.
+- `app/components/ui/field.tsx` — `Field` (label + error wrapper).
+- `app/components/ui/index.ts` — barrel re-export (optional convenience).
+
+Modified files:
+- `app/layout.tsx` — load fonts, apply font CSS-variable classes to `<html>`.
+- `app/globals.css` — point `--font-sans`/`--font-heading` at the next/font variables;
+  add additive radius / soft-warm-shadow / per-color tint-shade tokens.
+- `app/page.tsx` — consume `lib/jar-colors.ts`; use `Button`/`buttonClasses`, `cardClasses`,
+  `Badge`; delete local `jarColorStyles` and `emptyStateMarbleColors`.
+- `app/jar/page.tsx` — consume `lib/jar-colors.ts`; use `Button`/`buttonClasses`, `Badge`,
+  `cardClasses`; delete local `jarColorStyles`.
+- `app/jars/new/page.tsx` — consume `lib/jar-colors.ts`; use `Button`/`buttonClasses`,
+  `Input`, `Field`; delete local `marbleColors` / `MarbleColor` type.
+
+Untouched (regression net + out of scope):
+- `lib/storage.ts`, `lib/streak.ts`, all `__tests__/*`, `app/components/celebration-modal.tsx`,
+  `app/components/header.tsx`, configs.
+
+## Implementation Steps (ordered)
+
+Work bottom-up: tokens/fonts → shared modules → page migrations → verify. Each step leaves
+the build green.
+
+### Step 1 — Web fonts via `next/font` (`app/layout.tsx` + `app/globals.css`)
+
+In `app/layout.tsx`, import and configure the two Google fonts with distinct CSS-variable
+names (do **not** reuse `--font-sans`/`--font-heading` as the next/font `variable` — that
+would be self-referential against the `@theme` declaration):
+
+```tsx
+import { Fraunces, Inter } from "next/font/google";
+
+const inter = Inter({
+  subsets: ["latin"],
+  variable: "--font-inter",
+  display: "swap",
+});
+
+const fraunces = Fraunces({
+  subsets: ["latin"],
+  weight: ["400", "500", "600", "700"],
+  style: ["normal"],
+  variable: "--font-fraunces",
+  display: "swap",
+});
+```
+
+Apply both variable classes to `<html>` (keep the existing `<body>` classes exactly):
+
+```tsx
+<html lang="en" className={`${inter.variable} ${fraunces.variable}`}>
+  <body className="min-h-screen bg-cream font-sans text-ink antialiased">
+```
+
+In `app/globals.css`, change the two font entries inside `@theme inline` so the utilities
+resolve to the self-hosted fonts, keeping the current system stacks only as **fallbacks**
+(this satisfies "replace the system-font-only fallback chains" while avoiding FOUT/CLS):
+
+```css
+@theme inline {
+  /* …existing color tokens unchanged… */
+  --font-sans: var(--font-inter), "Segoe UI", "Helvetica Neue", Arial, sans-serif;
+  --font-heading: var(--font-fraunces), "Palatino Linotype", "Book Antiqua", Georgia, serif;
+}
+```
+
+Notes:
+- The `@layer base { h1,h2,h3 { font-family: var(--font-heading); } }` rule and the
+  `font-sans`/`font-heading` utility usages already in the JSX keep working unchanged — they
+  now resolve through the next/font variables defined on `<html>`.
+- `display: "swap"` + next/font's default `adjustFontFallback: true` emit `size-adjust`
+  fallback metrics, which is what prevents the layout shift called out in the acceptance
+  criteria. Do not set `adjustFontFallback: false`.
+
+### Step 2 — Additive design tokens (`app/globals.css`)
+
+Add a radius scale, a soft warm elevation token, and per-color tint/shade steps to the
+`@theme` block. **Additive only** — do not redefine Tailwind's built-in `rounded-*` /
+`shadow-*` scales, because the existing screens use `rounded-lg`, `shadow-sm`, `shadow-md`,
+`shadow-inner`, etc., and changing those globally would be a visual regression.
+
+Introduce, for example:
+
+```css
+@theme {
+  /* radius scale for later stages to consume */
+  --radius-pill: 9999px;
+
+  /* soft warm elevation — available to ST2–ST5; existing shadows stay as-is */
+  --shadow-warm: 0 1px 2px color-mix(in srgb, var(--ink) 8%, transparent),
+                 0 8px 24px color-mix(in srgb, var(--ink) 6%, transparent);
+}
+```
+
+For per-color tint/shade steps, add raw CSS custom properties (in `:root`) derived from the
+existing base colors with `color-mix`, e.g. for each marble color a `-tint` (lighter) and
+`-shade` (darker) step:
+
+```css
+:root {
+  /* …existing base colors unchanged… */
+  --coral-tint: color-mix(in srgb, var(--coral) 55%, white);
+  --coral-shade: color-mix(in srgb, var(--coral) 80%, var(--ink));
+  /* …repeat for mint, lavender, butter, sky, peach, lilac, sage… */
+}
+```
+
+These are **vocabulary** for ST2–ST5; ST1 does not need to consume them on screen. Document
+them in the file with a short comment block so the next stage finds them. (If the reviewer
+prefers ST1 to ship zero unused tokens, the tint/shade block can be deferred to ST2 — call
+this out in the PR description; the acceptance checkbox for tokens is satisfied either way
+as long as the radius + elevation scale lands.)
+
+### Step 3 — `lib/cn.ts`
+
+Tiny dependency-free class joiner (no `clsx`/`tailwind-merge` in the project):
+
+```ts
+export function cn(
+  ...classes: Array<string | false | null | undefined>
+): string {
+  return classes.filter(Boolean).join(" ");
+}
+```
+
+### Step 4 — `lib/jar-colors.ts` (single source of truth)
+
+Reconcile the three existing maps into one. Each marble color carries every token any of
+the three pages needs. Note the existing opacity values:
+- `app/page.tsx`: `fill` `/35` (butter `/45`), `border` **`/60`** (butter `/70`), `tint` `/10` (butter `/15`).
+- `app/jar/page.tsx`: identical except `border` **`/70`** for all colors.
+- `app/jars/new/page.tsx`: `swatch` solid, `jarFill` `/30`, `border` `/70`, `preview` `/20`.
+
+**Decision:** unify `border` to `/70` (the jar-detail value). The only resulting on-screen
+change is the home-dashboard card borders going from 60% → 70% alpha — a sub-perceptible
+10% opacity bump on a pastel border. This is the single intentional pixel difference and
+should be noted in the PR. (Strict-zero-diff alternative: keep two border tokens,
+`borderSoft` `/60` and `border` `/70`, and have `JarCard` on the dashboard use `borderSoft`.
+Prefer the unified `/70` unless the reviewer wants pixel-exact dashboard borders.)
+
+Proposed shape (all values are complete literal Tailwind classes):
+
+```ts
+export const jarColorOrder = [
+  "coral", "mint", "lavender", "butter",
+  "sky", "peach", "lilac", "sage",
+] as const;
+
+export type JarColorKey = (typeof jarColorOrder)[number];
+
+export type JarColorStyle = {
+  label: string;   // "Coral"          — color picker label
+  solid: string;   // "bg-coral"       — marble dot, swatch, empty-state, confetti
+  fill: string;    // "bg-coral/35"    — jar liquid fill (dashboard + detail)
+  border: string;  // "border-coral/70"
+  tint: string;    // "bg-coral/10"    — card tint
+  jarFill: string; // "bg-coral/30"    — new-jar preview fill
+  preview: string; // "bg-coral/20"    — new-jar preview card background
+};
+
+export const jarColors: Record<JarColorKey, JarColorStyle> = {
+  coral:    { label: "Coral",    solid: "bg-coral",    fill: "bg-coral/35",    border: "border-coral/70",    tint: "bg-coral/10",  jarFill: "bg-coral/30",    preview: "bg-coral/20" },
+  mint:     { label: "Mint",     solid: "bg-mint",     fill: "bg-mint/35",     border: "border-mint/70",     tint: "bg-mint/10",   jarFill: "bg-mint/30",     preview: "bg-mint/20" },
+  lavender: { label: "Lavender", solid: "bg-lavender", fill: "bg-lavender/35", border: "border-lavender/70", tint: "bg-lavender/10", jarFill: "bg-lavender/30", preview: "bg-lavender/20" },
+  butter:   { label: "Butter",   solid: "bg-butter",   fill: "bg-butter/45",   border: "border-butter/70",   tint: "bg-butter/15", jarFill: "bg-butter/30",   preview: "bg-butter/20" },
+  sky:      { label: "Sky",      solid: "bg-sky",      fill: "bg-sky/35",      border: "border-sky/70",      tint: "bg-sky/10",    jarFill: "bg-sky/30",      preview: "bg-sky/20" },
+  peach:    { label: "Peach",    solid: "bg-peach",    fill: "bg-peach/35",    border: "border-peach/70",    tint: "bg-peach/10",  jarFill: "bg-peach/30",    preview: "bg-peach/20" },
+  lilac:    { label: "Lilac",    solid: "bg-lilac",    fill: "bg-lilac/35",    border: "border-lilac/70",    tint: "bg-lilac/10",  jarFill: "bg-lilac/30",    preview: "bg-lilac/20" },
+  sage:     { label: "Sage",     solid: "bg-sage",     fill: "bg-sage/35",     border: "border-sage/70",     tint: "bg-sage/10",   jarFill: "bg-sage/30",     preview: "bg-sage/20" },
+};
+
+export const jarColorList = jarColorOrder.map((key) => ({ key, ...jarColors[key] }));
+
+// Solid swatch classes in palette order (empty-state grid + confetti pieces).
+export const jarColorSolids = jarColorOrder.map((key) => jarColors[key].solid);
+
+export function getJarColor(color: string): JarColorStyle {
+  return jarColors[color as JarColorKey] ?? jarColors.coral;
+}
+```
+
+This collapses `getJarColorStyles` (page + jar), `emptyStateMarbleColors`, `confettiColors`
+(if migrated later), and `marbleColors` into one map. (Note: `confettiColors` lives in the
+out-of-scope `celebration-modal.tsx`; leave it there for now — do not migrate it in ST1.)
+
+### Step 5 — `app/components/ui/button.tsx`
+
+Cover all primary/secondary button strings on the three pages. Two exports: a `Button`
+component (for real `<button>`s) and a `buttonClasses()` helper (for `<Link>`s that are
+styled as buttons — keeps Next `Link` semantics and `role="link"` intact, which several
+tests assert).
+
+```tsx
+import type { ComponentProps } from "react";
+import { cn } from "../../../lib/cn";
+
+export type ButtonVariant = "primary" | "secondary" | "ghost";
+export type ButtonSize = "sm" | "md" | "lg";
+
+const base =
+  "inline-flex items-center justify-center rounded-lg font-semibold shadow-sm transition " +
+  "focus:outline-none focus:ring-2 focus:ring-ink focus:ring-offset-2 focus:ring-offset-cream " +
+  "disabled:cursor-not-allowed";
+
+const variantClasses: Record<ButtonVariant, string> = {
+  primary: "bg-ink text-cream hover:bg-soft-ink disabled:bg-soft-ink/45",
+  secondary: "border border-line bg-white text-ink hover:border-soft-ink",
+  ghost: "text-ink hover:bg-line/40",
+};
+
+const sizeClasses: Record<ButtonSize, string> = {
+  sm: "px-4 py-2 text-sm",   // "Back" link
+  md: "px-5 py-3 text-sm",   // default CTA
+  lg: "px-5 py-4 text-base", // "Add today's marble"
+};
+
+export function buttonClasses(opts: {
+  variant?: ButtonVariant;
+  size?: ButtonSize;
+  className?: string;
+} = {}): string {
+  const { variant = "primary", size = "md", className } = opts;
+  return cn(base, variantClasses[variant], sizeClasses[size], className);
+}
+
+type ButtonProps = ComponentProps<"button"> & {
+  variant?: ButtonVariant;
+  size?: ButtonSize;
+};
+
+export function Button({
+  variant = "primary",
+  size = "md",
+  className,
+  type = "button",
+  ...props
+}: ButtonProps) {
+  return (
+    <button type={type} className={buttonClasses({ variant, size, className })} {...props} />
+  );
+}
+```
+
+Mapping of existing call sites (preserve any extra positional/utility classes via
+`className`):
+- `EmptyState` "Create your first jar" `<Link>` → `buttonClasses({ size: "md" })`.
+- Dashboard "+ New jar" `<Link>` → `buttonClasses({ size: "sm", className: "fixed right-5 top-5 z-10 shadow-md" })` (keep `px-4`; `sm` already gives `px-4 py-2` — adjust to `py-3` via className if exact padding matters: append `py-3`).
+- `NotFoundState` "Back to jars" `<Link>` → `buttonClasses()`.
+- jar "Back" `<Link>` → `buttonClasses({ variant: "secondary", size: "sm" })`.
+- jar "Finish this jar" `<button>` → `<Button>`.
+- jar "Add today's marble" `<button disabled>` → `<Button size="lg" className="mt-8 w-full sm:w-auto" disabled={...}>` (primary already includes `disabled:bg-soft-ink/45`).
+- new-jar "Create jar" `<button type="submit">` → `<Button type="submit">`.
+- new-jar "Cancel" `<Link>` → `buttonClasses({ variant: "secondary" })`.
+
+> Match the exact padding/`shadow` of each original site by passing overrides through
+> `className`; verify visually (Step 9) so no button changes size. The `acceptance` only
+> forbids *hand-rolled* `bg-ink px-5 py-3 …` strings — overrides for one-off positioning are
+> fine.
+
+### Step 6 — `app/components/ui/card.tsx`
+
+```tsx
+import type { ComponentProps } from "react";
+import { cn } from "../../../lib/cn";
+
+export function cardClasses(className?: string): string {
+  return cn("rounded-lg border border-line bg-white shadow-sm", className);
+}
+
+export function Card({ className, ...props }: ComponentProps<"div">) {
+  return <div className={cardClasses(className)} {...props} />;
+}
+```
+
+Call sites:
+- jar-detail white info panels (`Complete` / `Jar full`) currently
+  `rounded-lg border border-line bg-white/75 p-5 shadow-sm` → `<Card className="bg-white/75 p-5">…</Card>` (override `bg-white` → `bg-white/75`).
+- `JarCard` (dashboard) and the jar-detail `<aside>` are **color-tinted** and one is a
+  `<Link>`: use `cardClasses(cn(color.border, color.tint, "<extra layout/padding>"))` on the
+  element directly so the tinted border/tint comes from `lib/jar-colors.ts`. Keep their
+  hover/focus/translate classes via the `className` arg.
+- new-jar `JarPreview` `<aside>` (`border-2 ... ${previewClass}`) → it uses `border-2`, not
+  the Card default `border`; pass `cardClasses(cn("border-2", color.border, color.preview, "min-h-[320px] …"))` or keep it bespoke. Keeping the `border-2` weight is required to avoid a visual change — pass it explicitly.
+
+### Step 7 — `app/components/ui/badge.tsx`
+
+Cover the pill labels: `✓ Complete` (mint), streak `🔥` (butter), and the inline mint/butter
+"in a row" / "Complete" pills.
+
+```tsx
+import type { ComponentProps } from "react";
+import { cn } from "../../../lib/cn";
+
+export type BadgeTone = "success" | "streak" | "neutral";
+
+const toneClasses: Record<BadgeTone, string> = {
+  success: "border-mint/70 bg-mint/20 text-ink", // ✓ Complete (detail)
+  streak: "border-butter/70 bg-butter/20 text-ink",
+  neutral: "border-line bg-cream text-ink",
+};
+
+export function Badge({
+  tone = "neutral",
+  className,
+  ...props
+}: ComponentProps<"span"> & { tone?: BadgeTone }) {
+  return (
+    <span
+      className={cn(
+        "inline-flex items-center gap-1 rounded-full border px-3 py-1 text-xs font-semibold shadow-sm",
+        toneClasses[tone],
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+```
+
+Call sites — **preserve every `aria-label` and text node exactly** (tests assert them):
+- `JarCard` "✓ Complete" ribbon (`absolute right-3 top-3 … bg-cream`) →
+  `<Badge tone="success" className="absolute right-3 top-3 bg-cream">✓ Complete</Badge>`
+  (override `bg-mint/20` → `bg-cream` to keep the ribbon's cream fill).
+- `JarCard` streak pill (currently `aria-label={`${streakCount} day streak`}`, content
+  `🔥` + count, `px-2.5 py-1`) → `<Badge tone="streak" aria-label={...} className="mt-3 px-2.5">…</Badge>`. **Keep the `aria-label` and the `🔥`/count spans verbatim** — `page.test.tsx` checks `getByLabelText("3 day streak")` → `🔥3`.
+- jar-detail "✓ Complete" → `<Badge tone="success" className="mt-4 text-sm px-3">✓ Complete</Badge>` (size differs — `text-sm`, so override).
+- jar-detail "N days in a row 🔥" → `<Badge tone="streak" className="mt-4 text-sm px-3">{streakCount} days in a row 🔥</Badge>`. **Text must stay exactly `{n} days in a row 🔥`** — `jar/page.test.tsx` checks `getByText("3 days in a row 🔥")` and the negative `queryByText(/days in a row/)`.
+
+> Because several badge sites differ in `text-xs` vs `text-sm` and padding, allow those via
+> `className`. Do not try to over-parameterize size into the tone — keep the primitive small
+> and override per site.
+
+### Step 8 — `app/components/ui/input.tsx` + `field.tsx`
+
+`Input` (controlled, the page owns value/onChange/aria):
+
+```tsx
+import type { ComponentProps } from "react";
+import { cn } from "../../../lib/cn";
+
+export function Input({ className, ...props }: ComponentProps<"input">) {
+  return (
+    <input
+      className={cn(
+        "w-full rounded-lg border border-line bg-white px-4 py-3 text-base text-ink",
+        "shadow-sm outline-none transition focus:border-ink focus:ring-2 focus:ring-mint/40",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+```
+
+`Field` — label + optional error, wired so `getByLabelText` and `aria-describedby` keep
+working. It renders the label and error; the page passes the `Input` as `children` so it
+keeps full control of `type`/width/value and the `aria-*` wiring:
+
+```tsx
+import type { ReactNode } from "react";
+
+export function Field({
+  label,
+  htmlFor,
+  error,
+  children,
+}: {
+  label: string;
+  htmlFor: string;
+  error?: string;
+  children: ReactNode;
+}) {
+  return (
+    <div>
+      <label className="block text-sm font-semibold text-ink" htmlFor={htmlFor}>
+        {label}
+      </label>
+      <div className="mt-2">{children}</div>
+      {error ? (
+        <p className="mt-2 text-sm font-medium text-coral" id={`${htmlFor}-error`}>
+          {error}
+        </p>
+      ) : null}
+    </div>
+  );
+}
+```
+
+Call sites in `app/jars/new/page.tsx`:
+- Name field →
+  ```tsx
+  <Field label="Name" htmlFor="jar-name" error={nameError}>
+    <Input
+      id="jar-name"
+      value={name}
+      onChange={...}
+      placeholder="Daily reading"
+      maxLength={60}
+      required
+      aria-invalid={nameError ? "true" : "false"}
+      aria-describedby={nameError ? "jar-name-error" : undefined}
+    />
+  </Field>
+  ```
+- Target field → same pattern with `htmlFor="jar-target"`, `<Input type="number" className="w-36" min={5} max={365} …>`. The error `<p id="jar-target-error">` produced by `Field` matches the input's `aria-describedby`. **Keep `id`s `jar-name`/`jar-target` and error ids `*-error` exactly** — `new/page.test.tsx` uses `getByLabelText("Name")`/`("Target")` (label association) and the validation-message `getByText`s.
+
+> The current markup nests the input directly under the field `<div>` (no wrapping
+> `mt-2 div`); the wrapper above re-creates the `mt-2` spacing the original input had
+> (`className="mt-2 …"`). Verify the vertical rhythm is unchanged in Step 9; if the extra
+> wrapper shifts spacing, move `mt-2` onto the `Input` via `className` instead and drop the
+> wrapper div.
+
+The **color radio group** (`<fieldset>`/`<legend>` + `peer` radios) is not a text input and
+is **not** migrated to `Input`/`Field`. Leave its structure; only swap its data source to
+`jarColorList` from `lib/jar-colors.ts` (Step 4) and keep the `swatchClass`→`solid`,
+`previewClass`→`preview`, `jarFillClass`→`jarFill`, `borderClass`→`border`, `name`→`label`
+mapping. **Keep the `${color.label} jar preview` aria-label and the per-swatch `sr-only`
+label text exactly** — the test checks `getByLabelText("Coral jar preview")`,
+`getByLabelText("Mint")`, `getByLabelText("Sage")`.
+
+### Step 9 — Page migrations & cleanup
+
+For each of the three pages, in order:
+1. Replace the local color map with imports from `lib/jar-colors.ts`
+   (`getJarColor`, `jarColorList`, `jarColorSolids`).
+2. Delete the now-dead local definitions: `jarColorStyles` + `getJarColorStyles` +
+   `emptyStateMarbleColors` (`page.tsx`); `jarColorStyles` + `getJarColorStyles`
+   (`jar/page.tsx`); `marbleColors` + `MarbleColor` type (`jars/new/page.tsx`).
+   Map the old field names to the new ones (`dot`→`solid`; others unchanged).
+3. Swap button/card/badge/input strings to the primitives per Steps 5–8.
+4. Confirm no remaining hand-rolled `bg-ink px-5 py-3 …` button strings (grep).
+
+### Step 10 — Verify (see Validation Strategy)
+
+Run `pnpm tsc`, `pnpm test`, `pnpm build`; then a manual font/visual check.
+
+## Validation Strategy
+
+Automated (all must pass — acceptance criterion #5):
+- `pnpm tsc` — types compile (new modules + literal-union `JarColorKey`).
+- `pnpm test` — the full vitest suite (`app/__tests__/page.test.tsx`,
+  `app/jar/__tests__/page.test.tsx`, `app/jars/new/__tests__/page.test.tsx`,
+  `lib/streak.test.ts`) passes **unchanged**. These pin the exact accessible names, text
+  nodes, label associations, `aria-label`s, hrefs, and storage shapes — they are the
+  no-regression net. Do not edit them.
+- `pnpm build` — Next static export succeeds and `next/font` self-hosts the fonts.
+
+Targeted greps after migration:
+- `grep -rn "jarColorStyles\|marbleColors\|emptyStateMarbleColors" app/` → only matches in
+  `lib/jar-colors.ts`-derived names should remain; the three old copies are gone.
+- `grep -rn "bg-ink px-" app/page.tsx app/jar/page.tsx app/jars/new/page.tsx` → no results.
+
+Manual (acceptance criterion #1, #4 — fonts + no visual regression):
+- `pnpm dev` (port 5050) and load `/`, `/jars/new`, `/jar?id=…` in a browser. Headings
+  render in Fraunces, body in Inter. Use DevTools → Rendering → "disable local fonts" (or a
+  clean profile) to confirm there's no system-font fallback and no visible FOUT/CLS on
+  reload (Network throttled). Compare each screen side-by-side against `main` for pixel
+  parity, paying attention to: dashboard card borders (the intended 60→70 alpha change),
+  button sizes/padding, badge pills, and the new-jar form spacing.
+
+## Risks and Mitigations
+
+- **Test breakage from changed accessible names/markup.** Highest risk. Mitigation: the
+  primitives are pure class wrappers; every `aria-label`, visible text, `id`/`htmlFor`,
+  and `href` is preserved verbatim (called out per site in Steps 5–8). Run `pnpm test`
+  after each page migration, not just at the end.
+- **`getByLabelText` regression from `Field`.** If the label/input association or error `id`
+  drifts, the new-jar tests fail. Mitigation: `Field` sets `htmlFor`; the page sets the
+  matching `id`; error id is `${htmlFor}-error` matching the input's `aria-describedby`.
+- **Tailwind not generating moved classes.** If any class becomes a non-literal fragment,
+  the utility won't be generated and styling silently breaks. Mitigation: all color tokens
+  in `lib/jar-colors.ts` are complete literal strings; never concatenate color + opacity.
+- **Token refinement causing a global restyle.** Redefining built-in `rounded-*`/`shadow-*`
+  scales would shift every screen. Mitigation: tokens are **additive** (`--shadow-warm`,
+  `--radius-pill`, per-color `-tint`/`-shade`); existing utilities are untouched. ST2–ST5
+  consume the new tokens.
+- **next/font + static export at build.** `output: "export"` requires fonts fetched at build
+  time. Mitigation: `next/font/google` self-hosts during `next build`; verified by Step 10
+  `pnpm build`. No runtime/CDN font request, no new npm dependency.
+- **Dashboard border alpha 60→70.** Intentional, sub-perceptible. Mitigation: documented in
+  PR; zero-diff fallback (dual `border`/`borderSoft` tokens) offered in Step 4 if rejected.
+
+## Success Criteria
+
+Maps 1:1 to issue #38 acceptance criteria:
+- [ ] Headings render in Fraunces, body in Inter, loaded via `next/font`; no FOUT/CLS in a
+  fresh browser with system fonts absent.
+- [ ] `app/page.tsx`, `app/jar/page.tsx`, `app/jars/new/page.tsx` import
+  buttons/cards/badges/inputs from `app/components/ui/`; no hand-rolled
+  `bg-ink px-5 py-3 …` button strings remain.
+- [ ] Exactly one jar-color definition (`lib/jar-colors.ts`); the three previous copies
+  (`jarColorStyles` ×2, `marbleColors`) are deleted.
+- [ ] No visual/behavioral regression vs current screens (the one documented exception:
+  dashboard card border alpha 60%→70%).
+- [ ] `pnpm tsc`, `pnpm test`, `pnpm build` all pass.
+
+## Suggested PR / commit slicing
+
+To keep review tractable and each commit green, land in this order (each is independently
+buildable and test-passing):
+1. Fonts + token additions (`layout.tsx`, `globals.css`).
+2. `lib/cn.ts` + `lib/jar-colors.ts` + migrate the three pages to the color source
+   (no primitives yet) — deletes the three duplicate maps.
+3. `app/components/ui/*` primitives + migrate the three pages' button/card/badge/input
+   strings.
+
+A single PR is acceptable given the size; the slices above are commit boundaries.

--- a/lib/cn.ts
+++ b/lib/cn.ts
@@ -1,0 +1,5 @@
+export function cn(
+  ...classes: Array<string | false | null | undefined>
+): string {
+  return classes.filter(Boolean).join(" ");
+}

--- a/lib/jar-colors.test.ts
+++ b/lib/jar-colors.test.ts
@@ -1,0 +1,33 @@
+import {
+  getJarColor,
+  jarColorList,
+  jarColorOrder,
+  jarColorSolids,
+  jarColors,
+} from "./jar-colors";
+
+describe("jar colors", () => {
+  it("provides every shared presentation token for each supported color", () => {
+    expect(jarColorList.map(({ key }) => key)).toEqual(jarColorOrder);
+    expect(jarColorSolids).toEqual(
+      jarColorOrder.map((key) => jarColors[key].solid),
+    );
+
+    for (const key of jarColorOrder) {
+      expect(jarColors[key]).toMatchObject({
+        label: expect.any(String),
+        solid: expect.stringMatching(/^bg-/),
+        fill: expect.stringMatching(/^bg-/),
+        border: expect.stringMatching(/^border-/),
+        borderSoft: expect.stringMatching(/^border-/),
+        tint: expect.stringMatching(/^bg-/),
+        jarFill: expect.stringMatching(/^bg-/),
+        preview: expect.stringMatching(/^bg-/),
+      });
+    }
+  });
+
+  it("falls back to coral for legacy or unknown colors", () => {
+    expect(getJarColor("unknown")).toBe(jarColors.coral);
+  });
+});

--- a/lib/jar-colors.ts
+++ b/lib/jar-colors.ts
@@ -1,0 +1,117 @@
+export const jarColorOrder = [
+  "coral",
+  "mint",
+  "lavender",
+  "butter",
+  "sky",
+  "peach",
+  "lilac",
+  "sage",
+] as const;
+
+export type JarColorKey = (typeof jarColorOrder)[number];
+
+export type JarColorStyle = {
+  label: string;
+  solid: string;
+  fill: string;
+  border: string;
+  borderSoft: string;
+  tint: string;
+  jarFill: string;
+  preview: string;
+};
+
+export const jarColors: Record<JarColorKey, JarColorStyle> = {
+  coral: {
+    label: "Coral",
+    solid: "bg-coral",
+    fill: "bg-coral/35",
+    border: "border-coral/70",
+    borderSoft: "border-coral/60",
+    tint: "bg-coral/10",
+    jarFill: "bg-coral/30",
+    preview: "bg-coral/20",
+  },
+  mint: {
+    label: "Mint",
+    solid: "bg-mint",
+    fill: "bg-mint/35",
+    border: "border-mint/70",
+    borderSoft: "border-mint/60",
+    tint: "bg-mint/10",
+    jarFill: "bg-mint/30",
+    preview: "bg-mint/20",
+  },
+  lavender: {
+    label: "Lavender",
+    solid: "bg-lavender",
+    fill: "bg-lavender/35",
+    border: "border-lavender/70",
+    borderSoft: "border-lavender/60",
+    tint: "bg-lavender/10",
+    jarFill: "bg-lavender/30",
+    preview: "bg-lavender/20",
+  },
+  butter: {
+    label: "Butter",
+    solid: "bg-butter",
+    fill: "bg-butter/45",
+    border: "border-butter/70",
+    borderSoft: "border-butter/70",
+    tint: "bg-butter/15",
+    jarFill: "bg-butter/30",
+    preview: "bg-butter/20",
+  },
+  sky: {
+    label: "Sky",
+    solid: "bg-sky",
+    fill: "bg-sky/35",
+    border: "border-sky/70",
+    borderSoft: "border-sky/60",
+    tint: "bg-sky/10",
+    jarFill: "bg-sky/30",
+    preview: "bg-sky/20",
+  },
+  peach: {
+    label: "Peach",
+    solid: "bg-peach",
+    fill: "bg-peach/35",
+    border: "border-peach/70",
+    borderSoft: "border-peach/60",
+    tint: "bg-peach/10",
+    jarFill: "bg-peach/30",
+    preview: "bg-peach/20",
+  },
+  lilac: {
+    label: "Lilac",
+    solid: "bg-lilac",
+    fill: "bg-lilac/35",
+    border: "border-lilac/70",
+    borderSoft: "border-lilac/60",
+    tint: "bg-lilac/10",
+    jarFill: "bg-lilac/30",
+    preview: "bg-lilac/20",
+  },
+  sage: {
+    label: "Sage",
+    solid: "bg-sage",
+    fill: "bg-sage/35",
+    border: "border-sage/70",
+    borderSoft: "border-sage/60",
+    tint: "bg-sage/10",
+    jarFill: "bg-sage/30",
+    preview: "bg-sage/20",
+  },
+};
+
+export const jarColorList = jarColorOrder.map((key) => ({
+  key,
+  ...jarColors[key],
+}));
+
+export const jarColorSolids = jarColorOrder.map((key) => jarColors[key].solid);
+
+export function getJarColor(color: string): JarColorStyle {
+  return jarColors[color as JarColorKey] ?? jarColors.coral;
+}

--- a/package.json
+++ b/package.json
@@ -12,7 +12,6 @@
     "vitest": "vitest"
   },
   "dependencies": {
-    "framer-motion": "^12.40.0",
     "next": "^15.5.19",
     "react": "^19.2.7",
     "react-dom": "^19.2.7"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,9 +8,6 @@ importers:
 
   .:
     dependencies:
-      framer-motion:
-        specifier: ^12.40.0
-        version: 12.40.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       next:
         specifier: ^15.5.19
         version: 15.5.19(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
@@ -759,20 +756,6 @@ packages:
       picomatch:
         optional: true
 
-  framer-motion@12.40.0:
-    resolution: {integrity: sha512-uaBd3qC1v3KQqBEjwTUd183K6PbS+j0yR9w9VmEOLWA/tnUcSn8Xa3uck7t4dgpDoUss8xQTcj8W2L07lrnLFg==}
-    peerDependencies:
-      '@emotion/is-prop-valid': '*'
-      react: ^18.0.0 || ^19.0.0
-      react-dom: ^18.0.0 || ^19.0.0
-    peerDependenciesMeta:
-      '@emotion/is-prop-valid':
-        optional: true
-      react:
-        optional: true
-      react-dom:
-        optional: true
-
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -907,12 +890,6 @@ packages:
   min-indent@1.0.1:
     resolution: {integrity: sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==}
     engines: {node: '>=4'}
-
-  motion-dom@12.40.0:
-    resolution: {integrity: sha512-HxU3ZaBwNPVQUBQf1xxgq+7JrPNZvjLVxgbpEZL7RrWJnsxOf0/OM+yrHG9ogLQ31Do/r57Oz2gQWPK+6q62mg==}
-
-  motion-utils@12.39.0:
-    resolution: {integrity: sha512-8nadJAJjTtqRkmRF36FoJTrywK9nnFmnPwnSMyxaOCU7GDjN9RTMJIxx9De8ErM+vpPhMccr/6fo5WciyQLnMQ==}
 
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
@@ -1765,15 +1742,6 @@ snapshots:
     optionalDependencies:
       picomatch: 4.0.4
 
-  framer-motion@12.40.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
-    dependencies:
-      motion-dom: 12.40.0
-      motion-utils: 12.39.0
-      tslib: 2.8.1
-    optionalDependencies:
-      react: 19.2.7
-      react-dom: 19.2.7(react@19.2.7)
-
   fsevents@2.3.3:
     optional: true
 
@@ -1895,12 +1863,6 @@ snapshots:
   mdn-data@2.27.1: {}
 
   min-indent@1.0.1: {}
-
-  motion-dom@12.40.0:
-    dependencies:
-      motion-utils: 12.39.0
-
-  motion-utils@12.39.0: {}
 
   ms@2.1.3: {}
 


### PR DESCRIPTION
## Summary

Establishes the approved ST1 foundation for the premium-cozy redesign without changing screen behavior. This update resolves the review findings while keeping the accepted fonts, tokens, primitives, and jar-color consolidation intact.

## Changes

- Make input width caller-owned: the Name field explicitly fills its field and the Target field retains `w-36`, eliminating source-order utility conflicts.
- Remove the out-of-scope marble drop animation, floating cue, and `framer-motion` dependency; `/jar` now builds at 111 kB First Load JS.
- Keep the static-export configuration because it is already present on the `main` base. Commit `b16e528` removed the earlier Pages setup, and `b727b0b` subsequently restored `output`, `basePath`, `trailingSlash`, and unoptimized images for the current GitHub Pages-compatible app. There is no `next.config.ts` diff in this PR.
- Preserve the dashboard’s previous softer border alpha through `borderSoft` to avoid the optional visual change in the plan.

## Test Plan

- `pnpm tsc`
- `pnpm test` — 33 passed
- `pnpm build` — static export succeeds

Closes #38