### PR TITLE
ST2 — Signature glass jar &amp; dimensional marbles

### DIFF
--- a/app/components/__tests__/jar.test.tsx
+++ b/app/components/__tests__/jar.test.tsx
@@ -1,0 +1,56 @@
+import { render, screen } from "@testing-library/react";
+
+import { getJarFillPercent, Jar } from "../jar";
+
+describe("Jar", () => {
+  it("preserves the mini preview limit and fill percentage semantics", () => {
+    render(
+      <Jar
+        color="mint"
+        marbles={Array.from({ length: 13 }, (_, index) => `m-${index}`)}
+        name="Daily reading"
+        target={30}
+        variant="mini"
+      />,
+    );
+
+    const jar = screen.getByRole("img", {
+      name: "Daily reading jar is 43% full",
+    });
+
+    expect(jar.querySelectorAll(".jar__marble")).toHaveLength(12);
+  });
+
+  it("shows the latest 24 marbles in the large variant and keeps its animation hook", () => {
+    render(
+      <Jar
+        color="coral"
+        marbles={Array.from({ length: 25 }, (_, index) => `m-${index}`)}
+        name="Morning walk"
+        target={30}
+        variant="large"
+      />,
+    );
+
+    const jar = screen.getByRole("img", {
+      name: "Morning walk jar is 83% full",
+    });
+
+    expect(jar.querySelectorAll(".jar__marble")).toHaveLength(24);
+    expect(jar.querySelector(".jar__marble--drop")).toBeInTheDocument();
+  });
+
+  it("renders the color-labelled empty preview", () => {
+    render(<Jar color="sage" variant="preview" />);
+
+    const jar = screen.getByRole("img", { name: "Sage jar preview" });
+
+    expect(jar).toBeInTheDocument();
+    expect(jar.querySelectorAll(".jar__marble")).toHaveLength(0);
+  });
+
+  it("clamps invalid targets to an empty fill level", () => {
+    expect(getJarFillPercent(4, 0)).toBe(0);
+    expect(getJarFillPercent(8, 4)).toBe(100);
+  });
+});

--- a/app/components/jar.tsx
+++ b/app/components/jar.tsx
@@ -1,0 +1,90 @@
+import { cn } from "../../lib/cn";
+import { getJarColor } from "../../lib/jar-colors";
+import { type MarbleEntry } from "../../lib/storage";
+
+type FilledJarProps = {
+  color: string;
+  marbles: MarbleEntry[];
+  name: string;
+  target: number;
+  variant: "mini" | "large";
+};
+
+type PreviewJarProps = {
+  color: string;
+  variant: "preview";
+};
+
+type JarProps = (FilledJarProps | PreviewJarProps) & {
+  className?: string;
+};
+
+export function getJarFillPercent(marbleCount: number, target: number) {
+  if (target <= 0) {
+    return 0;
+  }
+
+  return Math.min(100, Math.round((marbleCount / target) * 100));
+}
+
+function getMarbleKey(marble: MarbleEntry, index: number) {
+  if (typeof marble === "string") {
+    return `${marble}-${index}`;
+  }
+
+  return `${marble.date}-${marble.at}`;
+}
+
+export function Jar(props: JarProps) {
+  const color = getJarColor(props.color);
+  const isPreview = props.variant === "preview";
+  const marbles = isPreview ? [] : props.marbles;
+  const fillPercent = isPreview
+    ? 0
+    : getJarFillPercent(marbles.length, props.target);
+  const visibleMarbles = isPreview
+    ? []
+    : props.variant === "mini"
+      ? marbles.slice(0, 12)
+      : marbles.slice(-24);
+  const ariaLabel = isPreview
+    ? `${color.label} jar preview`
+    : `${props.name} jar is ${fillPercent}% full`;
+
+  return (
+    <div
+      aria-label={ariaLabel}
+      className={cn("jar", `jar--${props.variant}`, props.className)}
+      role="img"
+    >
+      <div aria-hidden="true" className="jar__neck" />
+      <div aria-hidden="true" className="jar__rim" />
+      <div aria-hidden="true" className="jar__body">
+        {isPreview ? (
+          <span className={cn("jar__preview-tint", color.jarFill)} />
+        ) : (
+          <span
+            className={cn("jar__fill", color.fill)}
+            style={{ height: `${fillPercent}%` }}
+          />
+        )}
+        <span className="jar__base" />
+        {visibleMarbles.length > 0 ? (
+          <span className="jar__marbles">
+            {visibleMarbles.map((marble, index) => (
+              <span
+                className={cn(
+                  "jar__marble",
+                  props.variant === "large" && "jar__marble--drop",
+                  color.solid,
+                )}
+                key={getMarbleKey(marble, index)}
+              />
+            ))}
+          </span>
+        ) : null}
+        <span className="jar__reflection" />
+      </div>
+    </div>
+  );
+}

--- a/app/globals.css
+++ b/app/globals.css
@@ -120,9 +120,277 @@
   opacity: 0.7;
 }
 
+.jar {
+  position: relative;
+}
+
+.jar__neck,
+.jar__rim,
+.jar__body {
+  border: 2px solid color-mix(in srgb, var(--ink) 68%, transparent);
+}
+
+.jar__neck,
+.jar__rim {
+  position: absolute;
+  left: 50%;
+  transform: translateX(-50%);
+  background: linear-gradient(
+    100deg,
+    rgb(255 255 255 / 80%) 0%,
+    rgb(220 239 234 / 66%) 48%,
+    rgb(255 255 255 / 62%) 100%
+  );
+  box-shadow:
+    inset 2px 1px 0 rgb(255 255 255 / 80%),
+    0 2px 3px rgb(49 38 31 / 10%);
+}
+
+.jar__body {
+  position: absolute;
+  bottom: 0;
+  left: 50%;
+  overflow: hidden;
+  transform: translateX(-50%);
+  background: linear-gradient(
+    105deg,
+    rgb(255 255 255 / 72%) 0%,
+    rgb(220 239 234 / 38%) 46%,
+    rgb(255 255 255 / 55%) 100%
+  );
+  box-shadow:
+    inset 8px 0 14px rgb(255 255 255 / 50%),
+    inset -8px 0 14px rgb(49 38 31 / 8%),
+    inset 0 -10px 12px rgb(49 38 31 / 12%),
+    0 9px 15px rgb(49 38 31 / 10%);
+}
+
+.jar__fill,
+.jar__preview-tint {
+  position: absolute;
+  inset-inline: 0;
+  bottom: 0;
+  z-index: 0;
+}
+
+.jar__fill {
+  transition: height 240ms ease-out;
+}
+
+.jar__fill::after,
+.jar__preview-tint::after {
+  position: absolute;
+  inset: 0;
+  content: "";
+  background: linear-gradient(110deg, rgb(255 255 255 / 28%), transparent 42%);
+}
+
+.jar__preview-tint {
+  top: 0;
+  opacity: 0.72;
+}
+
+.jar__base {
+  position: absolute;
+  z-index: 3;
+  right: 12%;
+  bottom: 4px;
+  left: 12%;
+  height: 10px;
+  border-radius: 50%;
+  background: linear-gradient(180deg, rgb(255 255 255 / 46%), rgb(49 38 31 / 14%));
+  opacity: 0.72;
+}
+
+.jar__marbles {
+  position: absolute;
+  z-index: 2;
+  display: grid;
+}
+
+.jar__marble {
+  position: relative;
+  display: block;
+  border-radius: 9999px;
+  box-shadow:
+    inset -3px -4px 5px rgb(49 38 31 / 24%),
+    inset 2px 2px 3px rgb(255 255 255 / 38%),
+    0 3px 5px rgb(49 38 31 / 24%);
+}
+
+.jar__marble::after {
+  position: absolute;
+  top: 17%;
+  left: 22%;
+  width: 31%;
+  height: 23%;
+  border-radius: 9999px;
+  content: "";
+  background: rgb(255 255 255 / 78%);
+  filter: blur(0.4px);
+}
+
+.jar__reflection {
+  position: absolute;
+  z-index: 4;
+  top: 10%;
+  bottom: 12%;
+  left: 13%;
+  width: 15%;
+  border-radius: 9999px;
+  background: linear-gradient(180deg, rgb(255 255 255 / 72%), rgb(255 255 255 / 7%));
+  opacity: 0.8;
+  transform: rotate(5deg);
+}
+
+.jar--mini {
+  width: 7rem;
+  height: 10rem;
+}
+
+.jar--mini .jar__neck {
+  top: 0;
+  width: 3.5rem;
+  height: 1.25rem;
+  border-radius: 0.375rem 0.375rem 0.2rem 0.2rem;
+}
+
+.jar--mini .jar__rim {
+  top: 1rem;
+  width: 5rem;
+  height: 1.25rem;
+  border-radius: 0.5rem;
+}
+
+.jar--mini .jar__body {
+  width: 6rem;
+  height: 8rem;
+  border-radius: 0.75rem 0.75rem 1.75rem 1.75rem;
+}
+
+.jar--mini .jar__marbles {
+  right: 0.75rem;
+  bottom: 0.75rem;
+  left: 0.75rem;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 0.375rem;
+}
+
+.jar--mini .jar__marble {
+  width: 1rem;
+  height: 1rem;
+}
+
+.jar--large {
+  width: 100%;
+  max-width: 340px;
+  height: 430px;
+  margin-inline: auto;
+}
+
+.jar--large .jar__neck {
+  top: 0;
+  width: 10rem;
+  height: 2.5rem;
+  border-width: 4px;
+  border-radius: 0.5rem 0.5rem 0.3rem 0.3rem;
+}
+
+.jar--large .jar__rim {
+  top: 2.25rem;
+  width: 14rem;
+  height: 3rem;
+  border-width: 4px;
+  border-radius: 0.75rem;
+}
+
+.jar--large .jar__body {
+  width: 100%;
+  height: 370px;
+  border-width: 4px;
+  border-radius: 2rem 2rem 4rem 4rem;
+}
+
+.jar--large .jar__marbles {
+  right: 2.5rem;
+  bottom: 2rem;
+  left: 2.5rem;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 0.75rem;
+}
+
+.jar--large .jar__marble {
+  width: 2rem;
+  height: 2rem;
+}
+
+.jar--preview {
+  width: 10rem;
+  height: 13rem;
+}
+
+.jar--preview .jar__neck {
+  top: 0;
+  width: 5rem;
+  height: 1.75rem;
+  border-radius: 0.375rem 0.375rem 0.2rem 0.2rem;
+}
+
+.jar--preview .jar__rim {
+  top: 1.5rem;
+  width: 6rem;
+  height: 1.5rem;
+  border-radius: 0.5rem;
+}
+
+.jar--preview .jar__body {
+  width: 8rem;
+  height: 10rem;
+  border-radius: 0.75rem 0.75rem 2rem 2rem;
+}
+
+@keyframes jar-marble-drop {
+  from {
+    opacity: 0;
+    transform: translateY(-8px) scale(0.82);
+  }
+
+  to {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+  }
+}
+
+.jar__marble--drop {
+  animation: jar-marble-drop 260ms cubic-bezier(0.22, 1, 0.36, 1) both;
+}
+
+@media (min-width: 640px) {
+  .jar--large {
+    max-width: 400px;
+    height: 500px;
+  }
+
+  .jar--large .jar__body {
+    height: 430px;
+  }
+
+  .jar--large .jar__marbles {
+    grid-template-columns: repeat(6, 1fr);
+  }
+}
+
 @media (prefers-reduced-motion: reduce) {
   .confetti-piece {
     animation: none;
     opacity: 0;
+  }
+
+  .jar__fill {
+    transition: none;
+  }
+
+  .jar__marble--drop {
+    animation: none;
   }
 }

--- a/app/jar/page.tsx
+++ b/app/jar/page.tsx
@@ -4,6 +4,7 @@ import Link from "next/link";
 import { useEffect, useMemo, useRef, useState } from "react";
 
 import { CelebrationModal } from "../components/celebration-modal";
+import { getJarFillPercent, Jar as JarVisual } from "../components/jar";
 import { Badge, Button, buttonClasses, Card, cardClasses } from "../components/ui";
 import { cn } from "../../lib/cn";
 import { getJarColor } from "../../lib/jar-colors";
@@ -33,28 +34,12 @@ function getMarbleDate(marble: MarbleEntry) {
   return typeof marble === "string" ? marble : marble.date;
 }
 
-function getMarbleKey(marble: MarbleEntry, index: number) {
-  if (typeof marble === "string") {
-    return `${marble}-${index}`;
-  }
-
-  return `${marble.date}-${marble.at}`;
-}
-
 function getMarbleDateSet(marbles: MarbleEntry[]) {
   return new Set(
     marbles
       .map((marble) => getMarbleDate(marble))
       .filter((date) => /^\d{4}-\d{2}-\d{2}$/.test(date)),
   );
-}
-
-function getFillPercent(jar: Jar) {
-  if (jar.target <= 0) {
-    return 0;
-  }
-
-  return Math.min(100, Math.round((jar.marbles.length / jar.target) * 100));
 }
 
 function getLastFourteenDays(today: string) {
@@ -88,44 +73,6 @@ function NotFoundState() {
         Back to jars
       </Link>
     </section>
-  );
-}
-
-function LargeJar({ jar }: { jar: Jar }) {
-  const colorStyles = getJarColor(jar.color);
-  const fillPercent = getFillPercent(jar);
-  const previewMarbles = jar.marbles.slice(-24);
-
-  return (
-    <div
-      aria-label={`${jar.name} jar is ${fillPercent}% full`}
-      className="relative mx-auto h-[430px] w-full max-w-[340px] sm:h-[500px] sm:max-w-[400px]"
-      role="img"
-    >
-      <div className="absolute left-1/2 top-0 h-10 w-40 -translate-x-1/2 rounded-t-lg border-4 border-ink/75 bg-glass" />
-      <div className="absolute left-1/2 top-9 h-12 w-56 -translate-x-1/2 rounded-xl border-4 border-ink/75 bg-glass" />
-      <div className="absolute bottom-0 left-1/2 h-[370px] w-full -translate-x-1/2 overflow-hidden rounded-b-[4rem] rounded-t-[2rem] border-4 border-ink/75 bg-white/60 shadow-inner sm:h-[430px]">
-        <div
-          className={`absolute bottom-0 left-0 w-full transition-all ${colorStyles.fill}`}
-          style={{ height: `${fillPercent}%` }}
-        />
-        <div
-          aria-hidden="true"
-          className="absolute inset-x-10 bottom-8 grid grid-cols-4 gap-3 sm:grid-cols-6"
-        >
-          {previewMarbles.map((marble, index) => {
-            const marbleKey = getMarbleKey(marble, index);
-
-            return (
-              <span
-                className={`h-8 w-8 rounded-full shadow-sm ring-2 ring-white/80 ${colorStyles.solid}`}
-                key={marbleKey}
-              />
-            );
-          })}
-        </div>
-      </div>
-    </div>
   );
 }
 
@@ -299,7 +246,7 @@ export default function JarDetailPage() {
   }
 
   const colorStyles = getJarColor(jar.color);
-  const fillPercent = getFillPercent(jar);
+  const fillPercent = getJarFillPercent(jar.marbles.length, jar.target);
   const isCompleted = Boolean(jar.completedAt);
   const isFull = jar.marbles.length >= jar.target;
 
@@ -318,7 +265,13 @@ export default function JarDetailPage() {
             cn(colorStyles.border, colorStyles.tint, "px-5 py-8"),
           )}
         >
-          <LargeJar jar={jar} />
+          <JarVisual
+            color={jar.color}
+            marbles={jar.marbles}
+            name={jar.name}
+            target={jar.target}
+            variant="large"
+          />
         </aside>
 
         <div>

--- a/app/jars/new/page.tsx
+++ b/app/jars/new/page.tsx
@@ -11,36 +11,13 @@ import {
   Field,
   Input,
 } from "../../components/ui";
+import { Jar as JarVisual } from "../../components/jar";
 import { cn } from "../../../lib/cn";
-import { type JarColorStyle, jarColorList } from "../../../lib/jar-colors";
+import { jarColorList } from "../../../lib/jar-colors";
 import { type Jar, loadJars, saveJars } from "../../../lib/storage";
 
 function createJarId() {
   return globalThis.crypto?.randomUUID?.() ?? `jar-${Date.now()}`;
-}
-
-function JarPreview({ color }: { color: JarColorStyle }) {
-  return (
-    <aside
-      className={cardClasses(
-        cn(
-          "flex min-h-[320px] flex-col items-center justify-center border-2 px-8 py-10 text-center",
-          color.border,
-          color.preview,
-        ),
-      )}
-      aria-label={`${color.label} jar preview`}
-    >
-      <div className="relative h-52 w-40">
-        <div className="absolute left-1/2 top-0 h-7 w-20 -translate-x-1/2 rounded-t-md border-2 border-ink/75 bg-glass" />
-        <div className="absolute left-1/2 top-6 h-6 w-24 -translate-x-1/2 rounded-md border-2 border-ink/75 bg-glass" />
-        <div
-          className={`absolute bottom-0 left-1/2 h-40 w-32 -translate-x-1/2 rounded-b-[2rem] rounded-t-xl border-2 border-ink/75 ${color.jarFill} shadow-inner`}
-        />
-      </div>
-      <p className="mt-5 text-sm font-medium text-soft-ink">Empty jar</p>
-    </aside>
-  );
 }
 
 export default function NewJarPage() {
@@ -181,7 +158,18 @@ export default function NewJarPage() {
         </form>
       </div>
 
-      <JarPreview color={selectedColor} />
+      <aside
+        className={cardClasses(
+          cn(
+            "flex min-h-[320px] flex-col items-center justify-center border-2 px-8 py-10 text-center",
+            selectedColor.border,
+            selectedColor.preview,
+          ),
+        )}
+      >
+        <JarVisual color={selectedColor.key} variant="preview" />
+        <p className="mt-5 text-sm font-medium text-soft-ink">Empty jar</p>
+      </aside>
     </section>
   );
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -4,6 +4,7 @@ import Link from "next/link";
 import { useEffect, useState } from "react";
 
 import { Badge, buttonClasses, cardClasses } from "./components/ui";
+import { Jar as JarVisual } from "./components/jar";
 import { cn } from "../lib/cn";
 import {
   getJarColor,
@@ -11,14 +12,6 @@ import {
 } from "../lib/jar-colors";
 import { type Jar, loadCompletedJars, loadJars } from "../lib/storage";
 import { computeStreak } from "../lib/streak";
-
-function getFillPercent(jar: Jar) {
-  if (jar.target <= 0) {
-    return 0;
-  }
-
-  return Math.min(100, Math.round((jar.marbles.length / jar.target) * 100));
-}
 
 function EmptyState() {
   return (
@@ -48,40 +41,6 @@ function EmptyState() {
   );
 }
 
-function MiniJar({ jar }: { jar: Jar }) {
-  const colorStyles = getJarColor(jar.color);
-  const fillPercent = getFillPercent(jar);
-  const previewMarbles = jar.marbles.slice(0, 12);
-
-  return (
-    <div
-      aria-label={`${jar.name} jar is ${fillPercent}% full`}
-      className="relative h-40 w-28"
-      role="img"
-    >
-      <div className="absolute left-1/2 top-0 h-5 w-14 -translate-x-1/2 rounded-t-md border-2 border-ink/75 bg-glass" />
-      <div className="absolute left-1/2 top-4 h-5 w-20 -translate-x-1/2 rounded-md border-2 border-ink/75 bg-glass" />
-      <div className="absolute bottom-0 left-1/2 h-32 w-24 -translate-x-1/2 overflow-hidden rounded-b-[1.75rem] rounded-t-xl border-2 border-ink/75 bg-white/60 shadow-inner">
-        <div
-          className={`absolute bottom-0 left-0 w-full ${colorStyles.fill}`}
-          style={{ height: `${fillPercent}%` }}
-        />
-        <div
-          aria-hidden="true"
-          className="absolute inset-x-3 bottom-3 grid grid-cols-3 gap-1.5"
-        >
-          {previewMarbles.map((marble, index) => (
-            <span
-              className={`h-4 w-4 rounded-full shadow-sm ring-1 ring-white/80 ${colorStyles.solid}`}
-              key={`${marble}-${index}`}
-            />
-          ))}
-        </div>
-      </div>
-    </div>
-  );
-}
-
 function JarCard({ jar }: { jar: Jar }) {
   const colorStyles = getJarColor(jar.color);
   const streakCount = computeStreak(jar.marbles);
@@ -103,7 +62,13 @@ function JarCard({ jar }: { jar: Jar }) {
           ✓ Complete
         </Badge>
       ) : null}
-      <MiniJar jar={jar} />
+      <JarVisual
+        color={jar.color}
+        marbles={jar.marbles}
+        name={jar.name}
+        target={jar.target}
+        variant="mini"
+      />
       <h2 className="mt-5 w-full truncate font-heading text-2xl font-semibold text-ink">
         {jar.name}
       </h2>

--- a/docs/plans/issue-38-design-foundation.md
+++ b/docs/plans/issue-38-design-foundation.md
@@ -346,7 +346,7 @@ Call sites:
   `<Link>`: use `cardClasses(cn(color.border, color.tint, "<extra layout/padding>"))` on the
   element directly so the tinted border/tint comes from `lib/jar-colors.ts`. Keep their
   hover/focus/translate classes via the `className` arg.
-- new-jar `JarPreview` `<aside>` (`border-2 ... ${previewClass}`) → it uses `border-2`, not
+- new-jar preview `<aside>` (`border-2 ... ${previewClass}`) → it uses `border-2`, not
   the Card default `border`; pass `cardClasses(cn("border-2", color.border, color.preview, "min-h-[320px] …"))` or keep it bespoke. Keeping the `border-2` weight is required to avoid a visual change — pass it explicitly.
 
 ### Step 7 — `app/components/ui/badge.tsx`

--- a/docs/plans/issue-39-st2-jar-marbles.md
+++ b/docs/plans/issue-39-st2-jar-marbles.md
@@ -1,0 +1,175 @@
+# Implementation Plan — ST2: Signature glass jar & dimensional marbles
+
+Closes #39
+
+## Status
+
+**Implemented and verified on this branch (`plan/39-st2-signature-glass-jar-dimensional-marb`).**
+The work described below is realized by commit `c04e779` (`feat(jar): add shared glass jar
+visual`). At the time of writing, `pnpm tsc`, `pnpm test` (37 tests, 6 files), and
+`pnpm build` all pass. This document is therefore both the implementation plan *and* the
+verification record: a reviewer can check the branch against each step and acceptance
+criterion below.
+
+## Summary
+
+ST2 is the **signature visual upgrade** of the Premium-cozy redesign epic, built on the ST1
+foundation (design tokens + `lib/jar-colors.ts`, merged in #43). It replaces the three flat,
+duplicated `div`-based jars and flat marble dots with a single shared, premium **glass jar +
+dimensional marbles** component used by every screen.
+
+Three duplicated visuals — `MiniJar` (`app/page.tsx`), `LargeJar` (`app/jar/page.tsx`), and
+`JarPreview` (`app/jars/new/page.tsx`) — collapse into one `<Jar>` component
+(`app/components/jar.tsx`) with three variants: `mini`, `large`, `preview`. The glass body
+and marble dimensionality are pure CSS (gradients, layered inset shadows, pseudo-element
+highlights) in `app/globals.css`, so there is no new asset pipeline and no runtime cost
+beyond a few extra DOM nodes per jar.
+
+The hard constraint throughout: **no behavioral regression**. Fill percentage, marble
+counts, the marble-slice windows per variant, `role="img"` + `aria-label`, reduced-motion
+handling, and the `large`-variant marble-drop animation hook must all match current
+behavior exactly. The actual drop-spring tuning is deferred to ST5 — ST2 only preserves the
+entry point so ST5 has something to tune.
+
+## Scope and Assumptions
+
+In scope (and only this):
+
+- New `app/components/jar.tsx` exporting a single `Jar` component with a discriminated-union
+  prop type for the `mini` / `large` / `preview` variants, plus the shared
+  `getJarFillPercent` helper.
+- Glass + marble styling added to `app/globals.css` under a `.jar*` block (BEM-ish class
+  names), including the `@keyframes jar-marble-drop` hook and `prefers-reduced-motion`
+  overrides.
+- Migrate the three pages to render `<Jar … />` and delete the inline `MiniJar` /
+  `LargeJar` / `JarPreview` definitions.
+- A component test (`app/components/__tests__/jar.test.tsx`) locking down fill %, marble
+  counts/slices, the drop hook, and the preview aria label.
+
+Out of scope (do not touch):
+
+- `app/components/celebration-modal.tsx`, `app/components/header.tsx`, and the streak/day
+  grid on the detail page — ST2 is the jar visual only.
+- Drop-spring physics/tuning (ST5). ST2 keeps the `jar__marble--drop` hook in place but does
+  not refine the animation.
+- The `lib/jar-colors.ts` palette and the `fillPercent` math semantics — consumed as-is from
+  ST1; the per-color classes used are `color.fill` (fill band), `color.solid` (marble body),
+  `color.jarFill` (preview tint), and `color.label` (preview aria text).
+
+Assumptions:
+
+- ST1 is merged (it is — #43), so `getJarColor` and the design tokens (`--ink`, radius/shadow
+  scale, per-color tint/shade steps) exist.
+- `MarbleEntry` and `Jar` types live in `lib/storage.ts` and are imported, not redefined.
+- The fill-percentage formula stays `Math.min(100, Math.round((count / target) * 100))` with
+  `target <= 0 → 0`, matching pre-ST2 behavior.
+
+## Affected Areas
+
+| File | Change |
+| --- | --- |
+| `app/components/jar.tsx` | **New.** `Jar` component + `getJarFillPercent` + marble-key helper. |
+| `app/globals.css` | **Add** `.jar*` glass/marble styles, `@keyframes jar-marble-drop`, reduced-motion overrides, per-variant sizing + responsive `@media (min-width: 640px)` for `large`. |
+| `app/page.tsx` | Remove inline `MiniJar`; render `<Jar variant="mini" … />` inside `JarCard`. |
+| `app/jar/page.tsx` | Remove inline `LargeJar`; render `<Jar variant="large" … />`; keep `getJarFillPercent` import for the "N% full" caption. |
+| `app/jars/new/page.tsx` | Remove inline `JarPreview`; render `<Jar variant="preview" color={selectedColor.key} />`. |
+| `app/components/__tests__/jar.test.tsx` | **New.** Behavior lock-in tests. |
+
+## Implementation Steps (ordered)
+
+1. **Create the component** (`app/components/jar.tsx`).
+   - Import `cn` (`lib/cn`), `getJarColor` (`lib/jar-colors`), and `type MarbleEntry`
+     (`lib/storage`).
+   - Define a discriminated union: `FilledJarProps` (`variant: "mini" | "large"`, plus
+     `color`, `marbles: MarbleEntry[]`, `name`, `target`) and `PreviewJarProps`
+     (`variant: "preview"`, `color`), intersected with `{ className?: string }`. This makes
+     `marbles`/`name`/`target` required for filled jars and absent for the preview at the
+     type level.
+   - Export `getJarFillPercent(marbleCount, target)`: return `0` when `target <= 0`, else
+     `Math.min(100, Math.round((marbleCount / target) * 100))`.
+   - Compute, inside `Jar`: `color = getJarColor(props.color)`; `isPreview`; `fillPercent`
+     (0 for preview); `visibleMarbles` — **`mini` shows `marbles.slice(0, 12)`**, **`large`
+     shows `marbles.slice(-24)`** (latest 24), preview shows none; `ariaLabel` —
+     `` `${color.label} jar preview` `` for preview, else
+     `` `${props.name} jar is ${fillPercent}% full` ``.
+   - Render a `role="img"` root carrying `aria-label`, `cn("jar", \`jar--${variant}\`,
+     className)`. Children (all `aria-hidden`): `jar__neck`, `jar__rim`, `jar__body`
+     containing either `jar__preview-tint` (preview) or `jar__fill` with
+     `style={{ height: \`${fillPercent}%\` }}`, then `jar__base`, the `jar__marbles` grid
+     (each marble `cn("jar__marble", variant === "large" && "jar__marble--drop",
+     color.solid)`), and `jar__reflection`.
+   - Stable marble keys: `marble.date`-`marble.at` for object entries, `\`${marble}-${index}\``
+     for legacy string entries.
+
+2. **Add the styling** (`app/globals.css`).
+   - `.jar` is `position: relative`; `.jar__neck/__rim/__body` get the glass border
+     (`color-mix(in srgb, var(--ink) 68%, transparent)`).
+   - **Glass body**: diagonal `linear-gradient` tinted toward the ST1 mint/cream, layered
+     `box-shadow` insets (left highlight, right shade, bottom inner shadow) + an outer soft
+     drop shadow. A `jar__reflection` streak (rotated, white→transparent gradient) and the
+     `jar__fill::after` specular sweep sell the glass read.
+   - **Dimensional marbles**: `.jar__marble` is a circle with layered `box-shadow`
+     (inset bottom-right shade + inset top-left light + outer drop shadow) and a
+     `::after` specular dot (top-left, blurred). Marble color comes from `color.solid`.
+   - Per-variant sizing for `--mini` / `--large` / `--preview` (body radius, neck/rim
+     dimensions, marble grid `grid-template-columns` + gap + marble size). `--large` gets a
+     `@media (min-width: 640px)` bump (taller body, 6-column marble grid).
+   - `@keyframes jar-marble-drop` + `.jar__marble--drop` animation (the ST5 hook).
+   - `@media (prefers-reduced-motion: reduce)`: disable `.jar__fill` transition and the
+     `.jar__marble--drop` animation (alongside the existing confetti override).
+
+3. **Migrate `app/page.tsx`** — delete inline `MiniJar`; in `JarCard` render
+   `<JarVisual color={jar.color} marbles={jar.marbles} name={jar.name} target={jar.target}
+   variant="mini" />` (alias the import as `JarVisual` to avoid colliding with the `Jar`
+   storage type).
+
+4. **Migrate `app/jar/page.tsx`** — delete inline `LargeJar`; import
+   `{ getJarFillPercent, Jar as JarVisual }`; render the `large` variant; keep the existing
+   `fillPercent = getJarFillPercent(jar.marbles.length, jar.target)` for the visible
+   "N% full" caption so the on-screen number and the aria label stay in sync.
+
+5. **Migrate `app/jars/new/page.tsx`** — delete inline `JarPreview`; render
+   `<JarVisual color={selectedColor.key} variant="preview" />`.
+
+6. **Add tests** (`app/components/__tests__/jar.test.tsx`) — assert: `mini` with 13 marbles /
+   target 30 → "43% full" aria label and exactly 12 rendered `.jar__marble`; `large` with 25
+   marbles → "83% full", 24 marbles, and a `.jar__marble--drop` present; `preview` →
+   "Sage jar preview", 0 marbles; and `getJarFillPercent` edge cases (`(4,0)→0`, `(8,4)→100`).
+
+## Validation Strategy
+
+- `pnpm tsc` — the discriminated union must reject passing `marbles`/`name`/`target` to a
+  `preview` jar and require them for `mini`/`large`. **(Passes.)**
+- `pnpm test` — the new jar tests plus the existing page tests (`app/__tests__/page.test.tsx`,
+  `app/jar/__tests__/page.test.tsx`, `app/jars/new/__tests__/page.test.tsx`) confirm no
+  regression in fill %, counts, or aria labels. **(37 tests pass.)**
+- `pnpm build` — Next static export succeeds for `/`, `/jar`, `/jars/new`. **(Passes.)**
+- Visual check (manual / Playwright): on home, detail, and new-jar screens the jar reads as
+  glass (gradient + highlight streak) and marbles read as dimensional (shaded + shadowed +
+  specular dot). Optionally toggle `prefers-reduced-motion` to confirm the drop animation and
+  fill transition are suppressed.
+
+## Risks and Mitigations
+
+- **Behavioral drift in marble windows / fill math** → locked by tests asserting the exact
+  slice limits (12 for `mini`, latest-24 for `large`) and percentages.
+- **Type-name collision** (`Jar` component vs `Jar` storage type) → import the component as
+  `JarVisual` on every page; verified by `tsc`.
+- **Accessibility regression** → `role="img"` + the exact `"<name> jar is N% full"` /
+  `"<label> jar preview"` labels are asserted via `getByRole("img", { name })`.
+- **Overrunning into ST5** → only the `jar__marble--drop` hook + keyframes are added; no
+  spring tuning, so ST5 has a clean entry point.
+- **CSS-only dimensionality looking flat on some displays** → layered inset+outer shadows and
+  a pseudo-element specular highlight per marble, validated visually across the three screens.
+
+## Success Criteria (acceptance)
+
+- [x] One `<Jar>` renders all three contexts; `MiniJar` / `LargeJar` / `JarPreview` removed
+  (no remaining definitions in `app/` or `lib/`).
+- [x] Jar reads as glass (gradient + highlight); marbles read as dimensional (shaded,
+  shadowed, specular) — verifiable on home, detail, and new-jar.
+- [x] Fill percentage and marble counts match current behavior exactly (tests: 43% / 12,
+  83% / 24, preview 0).
+- [x] `aria-label` + `role="img"` + reduced-motion behavior preserved; `large` keeps the
+  marble-drop hook.
+- [x] `pnpm tsc`, `pnpm test`, `pnpm build` pass.


### PR DESCRIPTION
Closes #39

## ST2 — Signature glass jar & dimensional marbles

Replaces the three flat, duplicated `div`-based jars (`MiniJar`, `LargeJar`, `JarPreview`) with **one shared `<Jar>` component** (`app/components/jar.tsx`) rendering `mini` / `large` / `preview` variants. The premium glass body and dimensional marbles are pure CSS in `app/globals.css` (gradients + layered inset/outer shadows + pseudo-element speculars), so there is no new asset pipeline.

### What's in this PR
- **`app/components/jar.tsx`** — single `Jar` component (discriminated-union props) + `getJarFillPercent` helper.
- **`app/globals.css`** — `.jar*` glass + dimensional-marble styles, `@keyframes jar-marble-drop` (the ST5 tuning hook), per-variant sizing, responsive `large` bump, and `prefers-reduced-motion` overrides.
- **`app/page.tsx` / `app/jar/page.tsx` / `app/jars/new/page.tsx`** — migrated to `<Jar …>`; inline jar definitions removed.
- **`app/components/__tests__/jar.test.tsx`** — locks fill %, marble counts/slices, the drop hook, and aria labels.
- **`docs/plans/issue-39-st2-jar-marbles.md`** — the implementation plan / spec & verification record (this stage's deliverable).

### Behavior preserved (no regression)
- Fill math unchanged: `target <= 0 → 0`, else `min(100, round(count/target*100))`.
- Marble windows: `mini` shows first 12, `large` shows latest 24, `preview` shows none.
- `role="img"` + `aria-label` (`"<name> jar is N% full"` / `"<label> jar preview"`).
- Reduced-motion disables the fill transition and the marble-drop animation.
- ST5 drop-spring tuning is **out of scope** — only the `jar__marble--drop` entry point is kept.

### Verification
`pnpm tsc` ✓ · `pnpm test` ✓ (37 tests, 6 files) · `pnpm build` ✓ — all green on this branch.

Full acceptance-criteria checklist and step-by-step rationale: `docs/plans/issue-39-st2-jar-marbles.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)